### PR TITLE
Change Cursor of Custom Event to Signal Draggability

### DIFF
--- a/components/course-calendar/course-calendar.css
+++ b/components/course-calendar/course-calendar.css
@@ -103,3 +103,7 @@
 .calendar-item-last-choice .fc-content {
     color: #AA66CC;
 }
+
+.course-calendar .custom-event {
+    cursor: move;
+}

--- a/components/course-calendar/course-calendar.js
+++ b/components/course-calendar/course-calendar.js
@@ -558,6 +558,7 @@ var CourseCalendar = (function () {
     function makeCustomEvent(courseCalendar, eventId, eventTitle, start, end) {
         return {
             id: eventId,
+            className: 'custom-event',
             title: eventTitle,
             start: start,
             end: end,


### PR DESCRIPTION
Change the cursor of custom events from the "default" cursor to the "move" cursor. Should not affect normal events.