### PR TITLE
Made the Navbar mention the current semester, and adding some documentation for other contributors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+local-config.txt

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,435 @@
+# Complete local setup
+
+This guide runs the CheeseFork frontend on `http://localhost:8000` while using
+your own live Firebase project. This is the simplest way to test real Google
+sign-in, Firestore synchronization, sharing, feedback, group links, and calendar
+uploads locally.
+
+The Firebase Local Emulator Suite is not used here. Its Auth emulator can mock
+users, but it does not perform the real Google OAuth flow.
+
+## 1. Install the prerequisites
+
+Install:
+
+- A current version of Python 3
+- Node.js and npm
+- A Google account that can create a Firebase project
+
+From the repository root, install the linting dependencies:
+
+```powershell
+npm install
+```
+
+Do not open `index.html` directly with a `file://` URL. Authentication and
+browser storage require the site to be served over HTTP.
+
+## 2. Create and register a Firebase web app
+
+### Where configuration values are saved
+
+This project does not use a `.env` file. It is a static site with no bundler,
+build step, or backend process to read environment variables.
+
+Save the Firebase web configuration directly in these two files:
+
+- `cheesefork.js`, in the `config` object inside `firebaseInit()`
+- `course-widget-comments.html`, in the `config` object inside
+  `firebaseInit()`
+
+Use the same Firebase configuration in both places. Values such as `apiKey`,
+`authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, and `appId` are
+public client configuration and will be visible to visitors. Firebase protects
+data through Authentication and Security Rules, not by hiding these values.
+
+Never place private credentials in either file, including service-account JSON,
+private keys, GitHub personal access tokens, or server API secrets. Features
+that require private credentials need a separate backend or serverless
+function.
+
+1. Open <https://console.firebase.google.com/>.
+2. Select **Create a project** and choose a unique project ID.
+3. Google Analytics is optional for local development.
+4. In **Project overview**, select the Web (`</>`) icon.
+5. Register an app such as `cheesefork-local`.
+6. Do not enable Firebase Hosting unless you also want to deploy through it.
+7. Copy the displayed `firebaseConfig` object.
+
+A current config normally resembles:
+
+```javascript
+var config = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_PROJECT_ID.firebasestorage.app",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+```
+
+Use the exact values shown by your Firebase console. New default Storage
+buckets normally end in `.firebasestorage.app`; older ones may end in
+`.appspot.com`. A `databaseURL` is unnecessary because this project uses Cloud
+Firestore, not Firebase Realtime Database.
+
+Firebase web configuration is public application metadata, not a server secret.
+Security must be enforced with Authentication and Firebase Security Rules.
+
+## 3. Enable sign-in methods
+
+In Firebase Console:
+
+1. Open **Build > Authentication**.
+2. Select **Get started**.
+3. Under **Sign-in method**, enable **Google**.
+4. Select a project support email and save.
+5. Enable **Email/Password** as well. Enable the regular email/password option,
+   not email-link-only sign-in.
+6. Open **Authentication > Settings > Authorized domains**.
+7. Add `localhost` if it is not already present.
+
+Firebase projects created after April 28, 2025 do not automatically authorize
+`localhost`. Enter only the hostname, without `http://` or port `8000`.
+
+If you later deploy the fork, add its hostname too, for example
+`YOUR_USERNAME.github.io` or `schedule.example.com`.
+
+## 4. Create Cloud Firestore
+
+1. Open **Build > Firestore Database**.
+2. Select **Create database**.
+3. Choose a location close to the expected users. This choice is effectively
+   permanent.
+4. Start in **Production mode**.
+5. Open the **Rules** tab, replace the default rules with the rules below, and
+   select **Publish**.
+
+```text
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    // Schedule sharing in the current application requires public reads.
+    match /users/{userId} {
+      allow read: if true;
+      allow create, update, delete: if isOwner(userId);
+
+      match /semesters/{semesterId} {
+        allow read: if true;
+        allow create, update, delete: if isOwner(userId);
+      }
+    }
+
+    // Everyone may view feedback; only signed-in users may publish it.
+    match /courseFeedback/{courseId} {
+      allow read: if true;
+      allow create, update: if isSignedIn();
+      allow delete: if false;
+    }
+
+    // The existing report form does not require sign-in. Reports are private.
+    match /courseFeedbackReports/{courseId} {
+      allow read, delete: if false;
+      allow create, update: if true;
+    }
+
+    // The UI requires sign-in both to view and update community group links.
+    match /courseExtraDetails/{courseId} {
+      allow read, create, update: if isSignedIn();
+      allow delete: if false;
+    }
+  }
+}
+```
+
+No collections or documents need to be created manually. The application
+creates them when features are used:
+
+- `users/{uid}/semesters/{semester}` stores current schedules.
+- `users/{uid}` stores schedules only for legacy semesters 201701–201801.
+- `courseFeedback/{course}` stores feedback in a `posts` array.
+- `courseFeedbackReports/{course}` stores reports in a `posts` array.
+- `courseExtraDetails/{course}` stores WhatsApp, Telegram, and Discord links.
+
+These rules reproduce the current application's behavior, but two parts deserve
+review before a public production launch:
+
+- Public schedule reads make shared links work, but anyone who obtains a user
+  ID can read that user's semester document, including custom events.
+- The unauthenticated report endpoint can be abused. Requiring sign-in would be
+  safer, but the report UI must then also be changed to enforce sign-in.
+
+## 5. Create Cloud Storage
+
+Cloud Storage is needed only for remotely hosted `.ics` calendar files. Normal
+calendar downloads work without it.
+
+As of February 3, 2026, Cloud Storage for Firebase requires the pay-as-you-go
+Blaze plan, including use of a default bucket. Billing must therefore be enabled
+to make the hosted calendar-subscription feature work. Set budget alerts in
+Google Cloud before exposing the app publicly.
+
+1. Upgrade the Firebase project to **Blaze** if prompted.
+2. Open **Build > Storage** and select **Get started**.
+3. Create the default bucket.
+4. Keep the exact bucket name shown in the console; it must match
+   `storageBucket` in your Firebase web config.
+5. Open **Storage > Rules**, publish the following rules:
+
+```text
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{userId}/{fileName} {
+      allow read: if true;
+
+      allow create, update: if request.auth != null
+        && request.auth.uid == userId
+        && fileName.matches('.*[.]ics')
+        && request.resource.size < 1024 * 1024;
+
+      allow delete: if request.auth != null
+        && request.auth.uid == userId;
+    }
+  }
+}
+```
+
+Public reads are required for calendar clients, which cannot send a Firebase
+login token when subscribing to an `.ics` URL.
+
+## 6. Replace the original Firebase configuration
+
+The fork currently connects to the original `cheesefork-de9af` project. Replace
+the entire `config` object with the object copied in step 2 in both locations:
+
+1. `cheesefork.js`, inside `firebaseInit()`
+2. `course-widget-comments.html`, inside `firebaseInit()`
+
+Both copies must use identical values. The second copy powers the standalone
+course-feedback widget.
+
+Do not copy the original project's API key or project ID into your new Firebase
+project settings. Use only the values generated for your own web app.
+
+## 7. Point calendar uploads at your bucket
+
+The main app explicitly selects the original owner's secondary bucket:
+
+```javascript
+firebaseStorage = firebase.app().storage("gs://files.cheesefork.cf");
+```
+
+In `cheesefork.js`, change it to the default bucket from your config:
+
+```javascript
+firebaseStorage = firebase.storage();
+```
+
+The export flow also assumes that the original custom domain
+`https://files.cheesefork.cf/` serves Storage objects. That domain will not
+serve files from your bucket.
+
+For a local fork, use Firebase's generated download URL:
+
+1. Initialize `calendarUrl` to `null` rather than constructing a
+   `files.cheesefork.cf` URL.
+2. After `calFileRef.putString(...)` resolves, call
+   `snapshot.ref.getDownloadURL()`.
+3. Assign the returned URL to `calendarUrl`.
+4. Create the download link and enable the copy button only after that URL has
+   resolved.
+5. Keep the existing error handler, or add a `.catch(...)`.
+
+The resulting promise flow should have this shape:
+
+```javascript
+var calendarUrl = null;
+
+calFileRef
+  .putString(calendar, "raw", {
+    cacheControl: "public, max-age=0",
+  })
+  .then(function (snapshot) {
+    return snapshot.ref.getDownloadURL();
+  })
+  .then(function (downloadUrl) {
+    calendarUrl = downloadUrl;
+
+    var urlElement = $(
+      '<a target="_blank" rel="noopener">לחצו כאן להורדה</a>',
+    ).prop("href", calendarUrl);
+    exportCalendarDialog
+      .getModalBody()
+      .find(".calendar-link-placeholder")
+      .html(urlElement);
+    exportCalendarDialog.getButton("copy-link").enable();
+  })
+  .catch(function (error) {
+    alert("Error saving calendar to server: " + error.message);
+  });
+```
+
+Keep the copy button disabled while `calendarUrl` is `null`.
+
+## 8. Review non-Firebase production references
+
+The following external services can remain unchanged for local development,
+provided they are online:
+
+- `ug.cheesefork.cf` and `sap.cheesefork.cf` supply semester course catalogs.
+- `michael-maltsev.github.io/technion-calendar-events` supplies holidays.
+- `michael-maltsev.github.io/technion-histograms` supplies histogram data.
+- `michael-maltsev.github.io/technion-course-names` supplies course names.
+
+They are not part of your Firebase project. An internet connection is required.
+If their owners remove them or block access, the corresponding feature will
+stop working and you will need to host replacement datasets.
+
+The repository also contains production references that are unnecessary
+locally:
+
+- `CNAME` claims `cheesefork.cf`; remove or replace it before enabling GitHub
+  Pages on your fork.
+- Google Analytics uses the original `UA-115440973-1` property. Remove those
+  script blocks or replace them with your own analytics setup before deployment.
+- `share-histograms.html` loads its bookmarklet from `cheesefork.cf`; replace
+  that URL if you intend to own and operate the histogram contribution flow.
+
+### Secure the histogram contribution flow
+
+`share-histograms.js` currently decodes several credentials in
+`getGithubToken()` and sends them in `Authorization` headers to the GitHub API.
+It also writes directly to
+`michael-maltsev/technion-histograms`. Base64 encoding does not protect a
+credential: every visitor can recover it from the browser source.
+
+Do not replace those values with your own GitHub personal access token. A
+browser-only static site cannot safely hold a repository write credential.
+
+For local development, disable or avoid the histogram contribution bookmarklet;
+histogram viewing still works without it. To operate contribution uploads
+safely in production:
+
+1. Fork or create the histogram data repository.
+2. Remove all embedded tokens from the client code. Treat any previously
+   published token as compromised and revoke it in the account that issued it.
+3. Create a small authenticated backend endpoint, such as a serverless function
+   or GitHub App, that owns the repository credential.
+4. Validate the course, semester, category, file type, and maximum payload size
+   on that backend.
+5. Add rate limiting and abuse protection.
+6. Update `submitToGithub()` to call your endpoint without receiving or
+   exposing the repository credential.
+7. Update the hard-coded `michael-maltsev/technion-histograms` read and write
+   URLs to your repository and deployment.
+
+Deleting credentials in a new commit does not remove them from existing Git
+history, which is why revocation is required.
+
+## 9. Start the local site
+
+From the repository root, run:
+
+```powershell
+python -m http.server 8000
+```
+
+Open:
+
+<http://localhost:8000>
+
+Use `localhost`, not `127.0.0.1`, unless you also add `127.0.0.1` as an
+authorized Firebase Authentication domain.
+
+## 10. Verify every backend feature
+
+Use this order so failures are easy to isolate:
+
+1. Open DevTools and confirm there are no failed Firebase scripts.
+2. Select **Sign in**, then sign in with Google.
+3. Refresh the page and confirm the session remains signed in.
+4. Add a course and select a lecture or tutorial.
+5. In Firestore, confirm a document appears at
+   `users/{your-uid}/semesters/{current-semester}`.
+6. Open the site in a second tab and confirm schedule changes synchronize.
+7. Generate a share URL and open it in a private browser window. Confirm the
+   read-only schedule loads while signed out.
+8. Publish course feedback and confirm `courseFeedback/{course}` is created.
+9. Open a course group-link dialog, add a test link, and confirm
+   `courseExtraDetails/{course}` is created.
+10. Submit a feedback report and confirm
+    `courseFeedbackReports/{course}` is created. Its contents should not be
+    readable by the browser afterward.
+11. Export a non-empty calendar. Confirm the `.ics` object appears in Storage
+    under `{your-uid}/` and its generated URL downloads successfully.
+12. Sign out and confirm the schedule falls back to browser `localStorage`.
+
+Run the linter after making the code changes:
+
+```powershell
+npx eslint .
+```
+
+## 11. Troubleshooting
+
+### `auth/unauthorized-domain`
+
+Add `localhost` to **Authentication > Settings > Authorized domains**. Do not
+include a protocol or port.
+
+### Google popup closes or is blocked
+
+Allow popups for `http://localhost:8000`, disable strict popup-blocking
+extensions temporarily, and inspect the browser console for the Firebase error
+code.
+
+### `auth/operation-not-allowed`
+
+Enable the relevant provider under **Authentication > Sign-in method**.
+
+### `Missing or insufficient permissions`
+
+Publish the Firestore rules from step 4, confirm the user is signed in, and
+verify that both Firebase config copies point to the same project.
+
+### `storage/unauthorized`
+
+Publish the Storage rules from step 5 and ensure the first path segment is the
+signed-in user's Firebase UID.
+
+### `storage/no-default-bucket`
+
+Create the default Storage bucket and copy its exact name into the
+`storageBucket` config field.
+
+### `storage/quota-exceeded`
+
+Confirm that the project is on the Blaze plan and that billing is active.
+
+### Sign-in works but feedback does not
+
+Check the separate Firebase config in `course-widget-comments.html`, then check
+the `courseFeedback` Firestore rules.
+
+### The app says `Failed to load courses`
+
+This is not a Firebase error. Confirm internet access and inspect the request to
+the selected `ug.cheesefork.cf` or `sap.cheesefork.cf` catalog in the Network
+panel.
+
+### Firestore works but the copied calendar URL does not
+
+The app is probably still constructing a `files.cheesefork.cf` URL. Complete
+step 7 and use `snapshot.ref.getDownloadURL()` instead.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,234 @@
 
 ![logo](logo.png)
 
+CheeseFork is a Hebrew, right-to-left web application for building Technion
+semester schedules. It combines the official course catalog with an interactive
+weekly calendar, advanced course filters, schedule sharing, calendar export,
+grade histograms, and community course feedback.
+
+The application is available at [cheesefork.cf](https://cheesefork.cf).
+
+## Features
+
+- Search for courses by number or name and filter them by faculty, academic
+  framework, credit points, prerequisites, linked courses, and exam dates.
+- Build a weekly schedule by selecting lecture, tutorial, laboratory, and
+  project groups.
+- Detect overlapping lessons and preview course groups directly on the
+  timetable.
+- Add custom calendar events and use undo/redo while editing a schedule.
+- Save schedules locally without an account or synchronize them through
+  Firebase after signing in.
+- Share a read-only schedule using a generated URL.
+- Export lessons, exams, and semester events to an iCalendar (`.ics`) file.
+  Signed-in users can also create a remotely hosted calendar subscription.
+- Review changes made to course details after the official catalog is updated.
+- Browse community-contributed grade histograms and course feedback.
+- Access course group links shared by the community.
+- Use dark mode, print-friendly styles, and a guided first-run tour.
+
+## How it works
+
+CheeseFork is a static, build-free application. The browser loads the relevant
+semester catalog, creates a `CourseManager`, and passes the normalized course
+data to the search, selected-course, exam, and calendar components.
+
+```text
+Semester course catalog
+        |
+        v
+  CourseManager
+        |
+        +--> CourseSelect
+        +--> CourseButtonList
+        +--> CourseCalendar
+        +--> CourseExamInfo
+        |
+        +--> localStorage (anonymous users)
+        +--> Firebase Auth + Firestore (signed-in users)
+        +--> Firebase Storage (hosted iCalendar files)
+```
+
+Course catalogs are loaded at runtime from CheeseFork's external semester data
+services. Holiday and semester event data, grade histograms, feedback, and
+community links are fetched from their respective external sources as needed.
+Because the application has no bundling step, scripts and styles are loaded
+directly by `index.html`.
+
+## Technology stack
+
+### Frontend
+
+- HTML5 and CSS3 with a Hebrew RTL layout
+- Vanilla JavaScript written for ES5 compatibility
+- Bootstrap 4 RTL for layout and common UI elements
+- jQuery for DOM manipulation and event handling
+- FullCalendar 3 for the interactive weekly timetable
+- Moment.js for date and time handling
+- Selectize for searchable course selection
+- Intro.js for the onboarding tour
+- Font Awesome for icons
+- `ics.js` for iCalendar generation
+- JsDiff for displaying course metadata changes
+
+Third-party browser dependencies are vendored in `modules/`; the project does
+not use a frontend package manager, bundler, or transpiler at runtime.
+
+### Backend and data services
+
+- Firebase Authentication for Google and email sign-in
+- Cloud Firestore for user schedules, course feedback, reports, and community
+  course details
+- Firebase Storage for hosted `.ics` calendar subscriptions
+- External CheeseFork course catalogs for semester data
+- The `technion-calendar-events` data set for holidays and semester dates
+- The `technion-histograms` project for community grade distributions
+
+Firebase's client configuration is intentionally present in the browser code,
+as is standard for Firebase web applications. Access control must therefore be
+enforced by Firebase Security Rules rather than by treating that configuration
+as a secret.
+
+### Tooling and automation
+
+- ESLint with `eslint-plugin-compat`
+- Python 3 and `requests` for semester metadata maintenance
+- GitHub Actions for the scheduled semester update workflow
+- Static hosting configuration for GitHub Pages and Netlify
+
+## Repository structure
+
+```text
+.
+|-- index.html                    Main application document and script loader
+|-- cheesefork.js                 Application initialization, auth, persistence,
+|                                 sharing, export, and navigation
+|-- course-manager.js             Course model, parsing, links, and prerequisites
+|-- cheesefork.css                Main application styles
+|-- cheesefork-dark.css           Dark-mode styles
+|-- cheesefork-print.css          Print-specific styles
+|-- components/
+|   |-- course-select/            Course search and advanced filters
+|   |-- course-button-list/       Selected courses and course details
+|   |-- course-calendar/          Interactive FullCalendar timetable
+|   |-- course-exam-info/         Exam date display
+|   |-- course-feedback/          Community course feedback
+|   `-- histogram-browser/        Grade histogram viewer
+|-- modules/                      Vendored third-party browser libraries
+|-- ci/
+|   `-- semester_update.py        Updates semester metadata in index.html
+|-- .github/workflows/
+|   `-- deploy.yml                Scheduled and manual semester update workflow
+|-- share-histograms.html         Histogram contribution instructions
+|-- share-histograms.js           Histogram sharing bookmarklet
+|-- course-widget-*.html          Embeddable histogram and feedback widgets
+|-- assets/                       Guide images and alternate visual assets
+|-- icons/                        Favicons, PWA icons, and web manifest
+|-- netlify.toml                  Netlify response headers
+|-- CNAME                         Custom domain for static hosting
+`-- .nojekyll                     GitHub Pages static-file configuration
+```
+
+Each component directory contains the JavaScript and CSS for one UI area.
+`cheesefork.js` coordinates these components and owns cross-cutting behavior;
+course normalization and course-specific logic live in `course-manager.js`.
+
+## Local development
+
+Follow the [complete local setup guide](LOCAL_SETUP.md) to configure the local
+server, Firebase Authentication, Firestore, Storage, Security Rules, and all
+required fork-specific settings.
+
+## Code quality
+
+Run the linter from the repository root:
+
+```bash
+npx eslint .
+```
+
+Application JavaScript is linted as ES5 browser code. Keep global strict mode,
+four-space indentation, semicolons, and compatibility with the configured
+browser target. Vendored modules and generated/minified scripts are excluded
+from linting.
+
+The repository currently has no automated test suite. The `npm test` script is
+a placeholder and exits with an error, so changes should be linted and tested
+manually in the affected user flows.
+
+## Persistence and sharing
+
+Anonymous schedules are stored in `localStorage` under semester-specific keys.
+After a user signs in, CheeseFork listens to that user's semester document in
+Firestore and synchronizes course selections, group choices, metadata, and
+custom events in real time.
+
+Shared schedule URLs include a semester and Firebase user ID. Opening one of
+these links loads the owner's schedule in read-only mode. Do not place private
+information in custom events intended for a shared schedule.
+
+## Semester data maintenance
+
+Available-semester metadata is embedded in `index.html`. The
+`ci/semester_update.py` script retrieves current semester information and
+updates that metadata when necessary.
+
+The `Run semester update` GitHub Actions workflow:
+
+1. Runs every day at 09:00 UTC and can also be started manually.
+2. Installs Python and the `requests` dependency.
+3. Runs `python -u ./ci/semester_update.py`.
+4. Commits and pushes `index.html` when the semester list changes.
+
+The course catalog files themselves are maintained by separate CheeseFork data
+services and are selected at runtime according to the requested semester.
+
+## Deployment
+
+CheeseFork can be deployed by publishing the repository root to any static
+host; no build output directory is required.
+
+- `.nojekyll` keeps GitHub Pages from processing the site with Jekyll.
+- `CNAME` configures the `cheesefork.cf` custom domain.
+- `netlify.toml` applies the deployment's response headers.
+- The application manifest and icons are located in `icons/`.
+
+Before deploying a fork, replace or review the custom domain, Firebase project,
+external service URLs, analytics configuration, and corresponding Firebase
+Security Rules.
+
+## Known constraints
+
+- The application is designed specifically for Technion course and semester
+  formats; it is not a generic scheduling engine.
+- Most of the UI and course content are in Hebrew.
+- Complete operation depends on external course catalogs and community data
+  sources being available.
+- The codebase intentionally targets ES5/IE 11 compatibility and uses legacy
+  versions of several browser libraries.
+- Dependencies in `modules/` are checked into the repository and are not
+  automatically updated by `npm install`.
+- Authentication, shared schedules, feedback, and hosted calendar exports
+  require a correctly configured Firebase project.
+
+## Contributing
+
+1. Create a branch for the change.
+2. Keep course-domain logic in `course-manager.js` and UI-specific logic in the
+   relevant component directory.
+3. Preserve the build-free ES5 architecture and RTL behavior unless the change
+   explicitly introduces a broader migration.
+4. Run `npx eslint .`.
+5. Manually verify the affected flows in at least one desktop and one
+   mobile-sized viewport.
+6. Open a pull request describing the behavior changed and how it was tested.
+
+When adding or replacing a third-party browser dependency, include its license,
+verify browser compatibility, and document why the vendored file is needed.
+
 A scheduling helper web application for Technion students.
+
+## License
+
+CheeseFork is distributed under the
+[GNU General Public License v3.0](LICENSE).

--- a/cheesefork.js
+++ b/cheesefork.js
@@ -673,6 +673,10 @@
       semesterFriendlyName(currentSemester),
     );
 
+    $("#top-navbar-dropdown-semester-name").text(
+      semesterFriendlyName(currentSemester),
+    );
+
     if (!viewingSharedSchedule) {
       var semesterSelect = $("#top-navbar-semester").find(".dropdown-menu");
 

--- a/cheesefork.js
+++ b/cheesefork.js
@@ -1,937 +1,1081 @@
-'use strict';
+"use strict";
 
 /* global introJs, ColorHash, BootstrapDialog, ics, JsDiff, firebase, firebaseui, gtag */
 /* global CourseManager, CourseSelect, CourseButtonList, CourseExamInfo, CourseCalendar, CourseFeedback */
 /* global courses_from_rishum, availableSemesters, currentSemester, scheduleSharingUserId */
 
 (function () {
-    var courseManager = new CourseManager(courses_from_rishum);
-    var colorHash = new ColorHash();
-    var firestoreDb = null;
-    var firebaseStorage = null;
-    var viewingSharedSchedule = false;
-    var previewingFromSelectControl = null;
-    var stopScheduleWatching = null;
-    var currentSavedSession = null, savedSessionForUndo = null, savedSessionForRedo = null;
-    var metadataDiff = {};
+  var courseManager = new CourseManager(courses_from_rishum);
+  var colorHash = new ColorHash();
+  var firestoreDb = null;
+  var firebaseStorage = null;
+  var viewingSharedSchedule = false;
+  var previewingFromSelectControl = null;
+  var stopScheduleWatching = null;
+  var currentSavedSession = null,
+    savedSessionForUndo = null,
+    savedSessionForRedo = null;
+  var metadataDiff = {};
 
-    // UI components.
-    var loginDialog = null;
-    var courseSelect = null;
-    var courseButtonList = null;
-    var courseExamInfo = null;
-    var courseCalendar = null;
+  // UI components.
+  var loginDialog = null;
+  var courseSelect = null;
+  var courseButtonList = null;
+  var courseExamInfo = null;
+  var courseCalendar = null;
 
-    if (!crawlersInfo()) {
-        cheeseforkInit();
+  if (!crawlersInfo()) {
+    cheeseforkInit();
+  }
+
+  function cheeseforkInit() {
+    // Use overlayScrollbars only if the scrollbar has width. On desktop it
+    // usually does, on mobile it usually doesn't. It can be a very small
+    // non-zero number such as 0.0002 as well, only consider significant
+    // width.
+    if (getScrollBarWidth() > 0.5) {
+      $("body").overlayScrollbars({}).removeClass("os-host-rtl");
     }
 
-    function cheeseforkInit() {
-        // Use overlayScrollbars only if the scrollbar has width. On desktop it
-        // usually does, on mobile it usually doesn't. It can be a very small
-        // non-zero number such as 0.0002 as well, only consider significant
-        // width.
-        if (getScrollBarWidth() > 0.5) {
-            $('body').overlayScrollbars({ }).removeClass('os-host-rtl');
+    $('[data-toggle="tooltip"]').tooltip();
+
+    viewingSharedSchedule = scheduleSharingUserId ? true : false;
+
+    navbarInit();
+
+    if (!viewingSharedSchedule) {
+      courseSelect = new CourseSelect($("#course-select"), {
+        courseManager: courseManager,
+        onItemAdd: function (course) {
+          if (!courseButtonList.isCourseInList(course)) {
+            courseButtonList.addCourse(course);
+            courseCalendar.addCourse(course);
+            selectedCourseSave(course);
+            updateGeneralInfoLine();
+            courseExamInfo.renderCourses(
+              courseButtonList.getCourseNumbers(true),
+            );
+            // Can't apply filter inside onItemAdd since it changes the select contents.
+            setTimeout(function () {
+              courseSelect.filterApply();
+            }, 0);
+          }
+        },
+        onDropdownItemActivate: function (course) {
+          previewingFromSelectControl = course;
+
+          if (!courseButtonList.isCourseInList(course)) {
+            courseCalendar.addCourse(course);
+            courseExamInfo.renderCourses(
+              courseButtonList.getCourseNumbers(true).concat([course]),
+            );
+          }
+          courseExamInfo.setHighlighted(course);
+          courseCalendar.previewCourse(course);
+          courseButtonList.setFloatingCourseInfo(course);
+        },
+        onDropdownItemDeactivate: function (course) {
+          if (!courseButtonList.isCourseInList(course)) {
+            courseCalendar.removeCourse(course);
+            courseExamInfo.renderCourses(
+              courseButtonList.getCourseNumbers(true),
+            );
+          } else {
+            // Remove highlight
+            courseExamInfo.removeHighlighted(course);
+            courseCalendar.unpreviewCourse(course);
+          }
+
+          previewingFromSelectControl = null;
+        },
+        getSelectedCoursesForFilter: function () {
+          return courseButtonList.getCourseNumbers(true);
+        },
+      });
+    } else {
+      $("#top-navbar-home").removeClass("d-none");
+      $("#top-navbar-share").addClass("d-none");
+      $("#top-navbar-semester").addClass("d-none");
+      $("#course-select").hide();
+    }
+
+    courseButtonList = new CourseButtonList($("#course-button-list"), {
+      courseManager: courseManager,
+      colorGenerator: courseColorGenerator,
+      readonly: viewingSharedSchedule,
+      onHoverIn: function (course) {
+        courseExamInfo.setHovered(course);
+        if (previewingFromSelectControl) {
+          courseCalendar.unpreviewCourse(previewingFromSelectControl);
         }
+        courseCalendar.previewCourse(course);
+      },
+      onHoverOut: function (course) {
+        courseExamInfo.removeHovered(course);
+        courseCalendar.unpreviewCourse(course);
+        if (previewingFromSelectControl) {
+          courseCalendar.previewCourse(previewingFromSelectControl);
+        }
+      },
+      onEnableCourse: function (course) {
+        courseCalendar.addCourse(course);
+        courseCalendar.previewCourse(course);
+        selectedCourseSave(course);
+        updateGeneralInfoLine();
+        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
+        courseSelect.filterApply();
+      },
+      onDisableCourse: function (course) {
+        courseCalendar.removeCourse(course);
+        selectedCourseUnsave(course);
+        updateGeneralInfoLine();
+        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
+        courseSelect.filterApply();
+      },
+      onReorder: coursesOrderSave,
+    });
 
-        $('[data-toggle="tooltip"]').tooltip();
+    courseExamInfo = new CourseExamInfo($("#course-exam-info"), {
+      courseManager: courseManager,
+      colorGenerator: courseColorGenerator,
+      onHoverIn: function (course) {
+        courseButtonList.setHovered(course);
+        if (previewingFromSelectControl) {
+          courseCalendar.unpreviewCourse(previewingFromSelectControl);
+        }
+        courseCalendar.previewCourse(course);
+      },
+      onHoverOut: function (course) {
+        courseButtonList.removeHovered(course);
+        courseCalendar.unpreviewCourse(course);
+        if (previewingFromSelectControl) {
+          courseCalendar.previewCourse(previewingFromSelectControl);
+        }
+      },
+    });
 
-        viewingSharedSchedule = scheduleSharingUserId ? true : false;
-
-        navbarInit();
-
-        if (!viewingSharedSchedule) {
-            courseSelect = new CourseSelect($('#course-select'), {
-                courseManager: courseManager,
-                onItemAdd: function (course) {
-                    if (!courseButtonList.isCourseInList(course)) {
-                        courseButtonList.addCourse(course);
-                        courseCalendar.addCourse(course);
-                        selectedCourseSave(course);
-                        updateGeneralInfoLine();
-                        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
-                        // Can't apply filter inside onItemAdd since it changes the select contents.
-                        setTimeout(function () {
-                            courseSelect.filterApply();
-                        }, 0);
-                    }
-                },
-                onDropdownItemActivate: function (course) {
-                    previewingFromSelectControl = course;
-
-                    if (!courseButtonList.isCourseInList(course)) {
-                        courseCalendar.addCourse(course);
-                        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true).concat([course]));
-                    }
-                    courseExamInfo.setHighlighted(course);
-                    courseCalendar.previewCourse(course);
-                    courseButtonList.setFloatingCourseInfo(course);
-                },
-                onDropdownItemDeactivate: function (course) {
-                    if (!courseButtonList.isCourseInList(course)) {
-                        courseCalendar.removeCourse(course);
-                        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
-                    } else {
-                        // Remove highlight
-                        courseExamInfo.removeHighlighted(course);
-                        courseCalendar.unpreviewCourse(course);
-                    }
-
-                    previewingFromSelectControl = null;
-                },
-                getSelectedCoursesForFilter: function () {
-                    return courseButtonList.getCourseNumbers(true);
-                }
-            });
+    courseCalendar = new CourseCalendar($("#course-calendar"), {
+      courseManager: courseManager,
+      colorGenerator: courseColorGenerator,
+      readonly: viewingSharedSchedule,
+      onCourseHoverIn: function (course) {
+        courseButtonList.setHovered(course);
+        courseExamInfo.setHovered(course);
+      },
+      onCourseHoverOut: function (course) {
+        courseButtonList.removeHovered(course);
+        courseExamInfo.removeHovered(course);
+      },
+      onCourseConflictedStatusChanged: function (course, conflicted) {
+        if (conflicted) {
+          courseButtonList.setConflicted(course);
         } else {
-            $('#top-navbar-home').removeClass('d-none');
-            $('#top-navbar-share').addClass('d-none');
-            $('#top-navbar-semester').addClass('d-none');
-            $('#course-select').hide();
+          courseButtonList.removeConflicted(course);
         }
+      },
+      onLessonTypesHidden: function (course, lessonTypesHidden) {
+        courseButtonList.setLessonTypesHidden(course, lessonTypesHidden);
+      },
+      onLessonSelected: function (course, lessonNumber, lessonType) {
+        selectedLessonSave(course, lessonNumber, lessonType);
+      },
+      onLessonUnselected: function (course, lessonNumber, lessonType) {
+        selectedLessonUnsave(course, lessonNumber, lessonType);
+      },
+      onCustomEventAdded: function (eventId, eventData) {
+        customEventSave(eventId, eventData);
+      },
+      onCustomEventUpdated: function (eventId, eventData) {
+        customEventSave(eventId, eventData);
+      },
+      onCustomEventRemoved: function (eventId) {
+        customEventUnsave(eventId);
+      },
+    });
 
-        courseButtonList = new CourseButtonList($('#course-button-list'), {
-            courseManager: courseManager,
-            colorGenerator: courseColorGenerator,
-            readonly: viewingSharedSchedule,
-            onHoverIn: function (course) {
-                courseExamInfo.setHovered(course);
-                if (previewingFromSelectControl) {
-                    courseCalendar.unpreviewCourse(previewingFromSelectControl);
-                }
-                courseCalendar.previewCourse(course);
-            },
-            onHoverOut: function (course) {
-                courseExamInfo.removeHovered(course);
-                courseCalendar.unpreviewCourse(course);
-                if (previewingFromSelectControl) {
-                    courseCalendar.previewCourse(previewingFromSelectControl);
-                }
-            },
-            onEnableCourse: function (course) {
-                courseCalendar.addCourse(course);
-                courseCalendar.previewCourse(course);
-                selectedCourseSave(course);
-                updateGeneralInfoLine();
-                courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
-                courseSelect.filterApply();
-            },
-            onDisableCourse: function (course) {
-                courseCalendar.removeCourse(course);
-                selectedCourseUnsave(course);
-                updateGeneralInfoLine();
-                courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
-                courseSelect.filterApply();
-            },
-            onReorder: coursesOrderSave
-        });
+    $("#top-navbar-supported-content").removeClass(
+      "top-navbar-content-uninitialized",
+    );
 
-        courseExamInfo = new CourseExamInfo($('#course-exam-info'), {
-            courseManager: courseManager,
-            colorGenerator: courseColorGenerator,
-            onHoverIn: function (course) {
-                courseButtonList.setHovered(course);
-                if (previewingFromSelectControl) {
-                    courseCalendar.unpreviewCourse(previewingFromSelectControl);
-                }
-                courseCalendar.previewCourse(course);
-            },
-            onHoverOut: function (course) {
-                courseButtonList.removeHovered(course);
-                courseCalendar.unpreviewCourse(course);
-                if (previewingFromSelectControl) {
-                    courseCalendar.previewCourse(previewingFromSelectControl);
-                }
-            }
-        });
+    $("#footer-semester-name").text(semesterFriendlyName(currentSemester));
+    $("#footer-semester").removeClass("d-none");
 
-        courseCalendar = new CourseCalendar($('#course-calendar'), {
-            courseManager: courseManager,
-            colorGenerator: courseColorGenerator,
-            readonly: viewingSharedSchedule,
-            onCourseHoverIn: function (course) {
-                courseButtonList.setHovered(course);
-                courseExamInfo.setHovered(course);
-            },
-            onCourseHoverOut: function (course) {
-                courseButtonList.removeHovered(course);
-                courseExamInfo.removeHovered(course);
-            },
-            onCourseConflictedStatusChanged: function (course, conflicted) {
-                if (conflicted) {
-                    courseButtonList.setConflicted(course);
-                } else {
-                    courseButtonList.removeConflicted(course);
-                }
-            },
-            onLessonTypesHidden: function (course, lessonTypesHidden) {
-                courseButtonList.setLessonTypesHidden(course, lessonTypesHidden);
-            },
-            onLessonSelected: function (course, lessonNumber, lessonType) {
-                selectedLessonSave(course, lessonNumber, lessonType);
-            },
-            onLessonUnselected: function (course, lessonNumber, lessonType) {
-                selectedLessonUnsave(course, lessonNumber, lessonType);
-            },
-            onCustomEventAdded: function (eventId, eventData) {
-                customEventSave(eventId, eventData);
-            },
-            onCustomEventUpdated: function (eventId, eventData) {
-                customEventSave(eventId, eventData);
-            },
-            onCustomEventRemoved: function (eventId) {
-                customEventUnsave(eventId);
-            }
-        });
+    $("#right-content-bar").removeClass("invisible");
 
-        $('#top-navbar-supported-content').removeClass('top-navbar-content-uninitialized');
+    if (viewingSharedSchedule) {
+      firebaseInit();
+      watchSharedSchedule(function () {
+        $("#page-loader").hide();
+      });
+    } else {
+      var firebaseAuthUIInitialized = false;
 
-        $('#footer-semester-name').text(semesterFriendlyName(currentSemester));
-        $('#footer-semester').removeClass('d-none');
-
-        $('#right-content-bar').removeClass('invisible');
-
-        if (viewingSharedSchedule) {
-            firebaseInit();
-            watchSharedSchedule(function () {
-                $('#page-loader').hide();
-            });
-        } else {
-            var firebaseAuthUIInitialized = false;
-
-            if (typeof firebase !== 'undefined') {
-                try {
-                    firebaseInit();
-                    firebaseAuthUIInit(function () {
-                        watchSavedSchedule(function () {
-                            $('#page-loader').hide();
-                            showExtraContentOnLoad();
-                        });
-                    });
-                    firebaseAuthUIInitialized = true;
-                } catch (e) {
-                    // Firebase UI doesn't work on Edge/IE in private mode.
-                    // Will fall back to offline mode.
-                }
-            }
-
-            if (!firebaseAuthUIInitialized) {
-                watchSavedSchedule(function () {
-                    $('#page-loader').hide();
-                    showExtraContentOnLoad();
-                });
-            }
-        }
-    }
-
-    function courseColorGenerator(course) {
-        var str = courseManager.toOldCourseNumber(course);
-        // Fixup: both 114036 and 114246 get a green color, and both are taken at the same semester.
-        // So here we cause the color of 114246 to be different.
-        // Similar fixup: pink 124503, 124708 and 134019.
-        // Similar fixup: green 334222 and 336537.
-        // Similar fixup: green 034055 and 114052.
-        var coursePrefixForHashCalc = {
-            '114246': 'a',
-            '124708': 'c',
-            '134019': 'a',
-            '336537': 'a',
-            '034055': 'a',
-        };
-        if (coursePrefixForHashCalc[str]) {
-            str = coursePrefixForHashCalc[str] + str;
-        }
-        return colorHash.hex(str);
-    }
-
-    function showExtraContentOnLoad() {
-        return showIntro() || showCourseFeedbackPopup() || showThursdayGraphPopup() || showTechnionScansPopup();
-    }
-
-    function showIntro() {
+      if (typeof firebase !== "undefined") {
         try {
-            var dontShowDate = localStorage.getItem('dontShowIntro');
-            if (dontShowDate) {
-                return false;
-            }
+          firebaseInit();
+          firebaseAuthUIInit(function () {
+            watchSavedSchedule(function () {
+              $("#page-loader").hide();
+              showExtraContentOnLoad();
+            });
+          });
+          firebaseAuthUIInitialized = true;
         } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
+          // Firebase UI doesn't work on Edge/IE in private mode.
+          // Will fall back to offline mode.
         }
+      }
 
-        if (courseButtonList.getCourseNumbers(true).length > 0) {
-            try {
-                localStorage.setItem('dontShowIntro', Date.now().toString());
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-            return false;
-        }
-
-        introJs().setOptions({
-            nextLabel: 'הבא',
-            prevLabel: 'קודם',
-            skipLabel: 'דלג',
-            doneLabel: 'בואו נתחיל',
-            disableInteraction: true,
-            exitOnOverlayClick: false,
-            showStepNumbers: false,
-            scrollToElement: false,
-            helperElementPadding: 0
-        }).onexit(function () {
-            try {
-                localStorage.setItem('dontShowIntro', Date.now().toString());
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }).start();
-
-        return true;
+      if (!firebaseAuthUIInitialized) {
+        watchSavedSchedule(function () {
+          $("#page-loader").hide();
+          showExtraContentOnLoad();
+        });
+      }
     }
+  }
 
-    function showCourseFeedbackPopup() {
-        var now = Date.now();
+  function courseColorGenerator(course) {
+    var str = courseManager.toOldCourseNumber(course);
+    // Fixup: both 114036 and 114246 get a green color, and both are taken at the same semester.
+    // So here we cause the color of 114246 to be different.
+    // Similar fixup: pink 124503, 124708 and 134019.
+    // Similar fixup: green 334222 and 336537.
+    // Similar fixup: green 034055 and 114052.
+    var coursePrefixForHashCalc = {
+      114246: "a",
+      124708: "c",
+      134019: "a",
+      336537: "a",
+      "034055": "a",
+    };
+    if (coursePrefixForHashCalc[str]) {
+      str = coursePrefixForHashCalc[str] + str;
+    }
+    return colorHash.hex(str);
+  }
 
-        var fromDate = new Date(availableSemesters[currentSemester].start);
-        fromDate.setDate(fromDate.getDate() - 7);
+  function showExtraContentOnLoad() {
+    return (
+      showIntro() ||
+      showCourseFeedbackPopup() ||
+      showThursdayGraphPopup() ||
+      showTechnionScansPopup()
+    );
+  }
 
-        var toDate = new Date(availableSemesters[currentSemester].start);
-        toDate.setDate(toDate.getDate() + 7);
-
-        // If the semester is starting, suggest to give feedback on previous semesters.
-        if (now > fromDate && now < toDate) {
-            return showCourseFeedbackPopupPrevSemesters();
-        }
-
-        fromDate = new Date(availableSemesters[currentSemester].end);
-        // Add several days to end date for a late notification (allow to do some exams).
-        fromDate.setDate(fromDate.getDate() + 7);
-
-        // If the semester ended, suggest to leave feedback.
-        if (now > fromDate) {
-            return showCourseFeedbackPopupThisSemester();
-        }
-
+  function showIntro() {
+    try {
+      var dontShowDate = localStorage.getItem("dontShowIntro");
+      if (dontShowDate) {
         return false;
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
     }
 
-    function showCourseFeedbackPopupPrevSemesters() {
+    if (courseButtonList.getCourseNumbers(true).length > 0) {
+      try {
+        localStorage.setItem("dontShowIntro", Date.now().toString());
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+      return false;
+    }
+
+    introJs()
+      .setOptions({
+        nextLabel: "הבא",
+        prevLabel: "קודם",
+        skipLabel: "דלג",
+        doneLabel: "בואו נתחיל",
+        disableInteraction: true,
+        exitOnOverlayClick: false,
+        showStepNumbers: false,
+        scrollToElement: false,
+        helperElementPadding: 0,
+      })
+      .onexit(function () {
         try {
-            var dontShowDate = localStorage.getItem('dontShowPrevCourseFeedbackPopup_' + currentSemester);
-            if (dontShowDate) {
-                return false;
-            }
+          localStorage.setItem("dontShowIntro", Date.now().toString());
         } catch (e) {
+          // localStorage is not available in IE/Edge when running from a local file.
+        }
+      })
+      .start();
+
+    return true;
+  }
+
+  function showCourseFeedbackPopup() {
+    var now = Date.now();
+
+    var fromDate = new Date(availableSemesters[currentSemester].start);
+    fromDate.setDate(fromDate.getDate() - 7);
+
+    var toDate = new Date(availableSemesters[currentSemester].start);
+    toDate.setDate(toDate.getDate() + 7);
+
+    // If the semester is starting, suggest to give feedback on previous semesters.
+    if (now > fromDate && now < toDate) {
+      return showCourseFeedbackPopupPrevSemesters();
+    }
+
+    fromDate = new Date(availableSemesters[currentSemester].end);
+    // Add several days to end date for a late notification (allow to do some exams).
+    fromDate.setDate(fromDate.getDate() + 7);
+
+    // If the semester ended, suggest to leave feedback.
+    if (now > fromDate) {
+      return showCourseFeedbackPopupThisSemester();
+    }
+
+    return false;
+  }
+
+  function showCourseFeedbackPopupPrevSemesters() {
+    try {
+      var dontShowDate = localStorage.getItem(
+        "dontShowPrevCourseFeedbackPopup_" + currentSemester,
+      );
+      if (dontShowDate) {
+        return false;
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+    }
+
+    var prevSemesters = Object.keys(availableSemesters).sort().reverse();
+    prevSemesters = prevSemesters.slice(
+      prevSemesters.indexOf(currentSemester) + 1,
+    );
+    prevSemesters = prevSemesters.slice(0, 3);
+
+    var prevSemesterLinks = $("<div>");
+    prevSemesters.forEach(function (semester) {
+      var link = $("<a>", {
+        href: "?semester=" + encodeURIComponent(semester),
+        text: semesterFriendlyName(semester),
+      });
+      prevSemesterLinks.append(link, "<br>");
+    });
+
+    prevSemesterLinks = prevSemesterLinks.html();
+
+    BootstrapDialog.show({
+      title: "פרסום חוות דעת עבור סמסטרים קודמים",
+      message:
+        "<div>" +
+        "זוכרים את הפעם האחרונה שבה הרכבתם מערכת? את התחושה שהמידע היבש על הקורסים לא מספיק? את החיפושים אחרי מידע נוסף והשאלות בפייסבוק?<br>" +
+        "<br>" +
+        "עכשיו תורכם לתרום מניסיונכם לדורות הבאים, והפעם אפשר לעשות את זה ממש פה! עברו לסמסטרים הקודמים והשאירו חוות דעת על קורסים שעשיתם:" +
+        "<br>" +
+        prevSemesterLinks +
+        '<div class="row text-center my-4">' +
+        '<div class="col-3"><i class="fas fa-3x fa-thumbs-up"></i></div>' +
+        '<div class="col-3"><i class="fas fa-3x fa-thumbs-down"></i></div>' +
+        '<div class="col-3"><i class="fas fa-3x fa-feather-alt"></i></div>' +
+        '<div class="col-3"><i class="fas fa-3x fa-dumbbell"></i></div>' +
+        "</div>" +
+        "</div>" +
+        '<div class="form-check">' +
+        '<input class="form-check-input" type="checkbox" id="dont-show-course-feedback-popup"> ' +
+        '<label class="form-check-label" for="dont-show-course-feedback-popup">' +
+        "אל תציג את ההודעה שוב" +
+        "</label>" +
+        "</div>",
+      buttons: [
+        {
+          label: "סגור",
+          action: function (dialog) {
+            dialog.close();
+          },
+        },
+      ],
+      onhide: function (dialog) {
+        if (
+          document.getElementById("dont-show-course-feedback-popup").checked
+        ) {
+          gtag("event", "course-feedback-prev-dont-show");
+
+          try {
+            localStorage.setItem(
+              "dontShowPrevCourseFeedbackPopup_" + currentSemester,
+              Date.now().toString(),
+            );
+          } catch (e) {
             // localStorage is not available in IE/Edge when running from a local file.
+          }
+        }
+      },
+    });
+
+    return true;
+  }
+
+  function showCourseFeedbackPopupThisSemester() {
+    try {
+      var dontShowDate = localStorage.getItem(
+        "dontShowThisCourseFeedbackPopup_" + currentSemester,
+      );
+      if (dontShowDate) {
+        return false;
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+    }
+
+    var courseNumbers = courseButtonList.getCourseNumbers(true);
+    if (courseNumbers.length === 0) {
+      return false;
+    }
+
+    var courses = courseNumbers.map(function (course) {
+      return {
+        course: courseManager.toNewCourseNumber(course),
+        title: courseManager.getTitle(course),
+      };
+    });
+
+    var courseFeedback = new CourseFeedback(null, {});
+    courseFeedback.endOfSemesterFeedbackDialog(courses, {
+      dialogHtml:
+        "<div>" +
+        "זוכרים את הפעם האחרונה שבה הרכבתם מערכת? את התחושה שהמידע היבש על הקורסים לא מספיק? את החיפושים אחרי מידע נוסף והשאלות בפייסבוק?<br>" +
+        "<br>" +
+        "עכשיו תורכם לתרום מניסיונכם לדורות הבאים, והפעם אפשר לעשות את זה ממש פה!" +
+        "</div>" +
+        '<div class="form-check my-3">' +
+        '<input class="form-check-input" type="checkbox" id="dont-show-course-feedback-popup"> ' +
+        '<label class="form-check-label" for="dont-show-course-feedback-popup">' +
+        "אל תציג את ההודעה שוב" +
+        "</label>" +
+        "</div>",
+      postHtml: null,
+      onHide: function (dialog) {
+        if (
+          document.getElementById("dont-show-course-feedback-popup").checked
+        ) {
+          gtag("event", "course-feedback-this-dont-show");
+
+          try {
+            localStorage.setItem(
+              "dontShowThisCourseFeedbackPopup_" + currentSemester,
+              Date.now().toString(),
+            );
+          } catch (e) {
+            // localStorage is not available in IE/Edge when running from a local file.
+          }
+        } else {
+          try {
+            localStorage.removeItem(
+              "dontShowThisCourseFeedbackPopup_" + currentSemester,
+            );
+          } catch (e) {
+            // localStorage is not available in IE/Edge when running from a local file.
+          }
+        }
+      },
+      onSharingDone: function () {
+        gtag("event", "course-feedback-this-shared");
+
+        try {
+          localStorage.setItem(
+            "dontShowThisCourseFeedbackPopup_" + currentSemester,
+            Date.now().toString(),
+          );
+        } catch (e) {
+          // localStorage is not available in IE/Edge when running from a local file.
+        }
+      },
+    });
+
+    return true;
+  }
+
+  function showThursdayGraphPopup() {
+    if (new Date() < new Date("2019-05-09T08:00:00")) {
+      // Don't show before the first graph is available.
+      return false;
+    }
+
+    try {
+      var nextShowDate = localStorage.getItem("nextShowThursdayGraphPopup");
+      if (nextShowDate && Date.now() < nextShowDate) {
+        return false;
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+    }
+
+    BootstrapDialog.show({
+      title: "הגרף השבועי",
+      message:
+        "בכל יום חמישי אנחנו מפרסמים בעמוד הפייסבוק שלנו גרף מעניין שקשור למקצועות בטכניון.<br>" +
+        "<br>" +
+        '<div class="form-check">' +
+        '<input class="form-check-input" type="checkbox" id="dont-show-thursday-graph-popup"> ' +
+        '<label class="form-check-label" for="dont-show-thursday-graph-popup">' +
+        "אל תציג את ההודעה פעם בשבוע" +
+        "</label>" +
+        "</div>" +
+        "<br>" +
+        '<div class="facebook-iframe-container"></div>',
+      onshown: function (dialog) {
+        var modalBody = dialog.getModalBody();
+        var width = Math.floor(modalBody.width());
+        var height = 400;
+        var frameSrc =
+          "https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fcheesefork.technion%2F&tabs=timeline" +
+          "&width=" +
+          width +
+          "&height=" +
+          height +
+          "&small_header=true&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=863730240682785";
+        var frameElem = $(
+          '<iframe style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>',
+        )
+          .attr("src", frameSrc)
+          .width(width)
+          .height(height);
+        modalBody.find(".facebook-iframe-container").html(frameElem);
+      },
+      buttons: [
+        {
+          label: "סגור",
+          action: function (dialog) {
+            dialog.close();
+          },
+        },
+      ],
+      onhide: function (dialog) {
+        var nextShowDate = new Date();
+
+        if (document.getElementById("dont-show-thursday-graph-popup").checked) {
+          gtag("event", "thursday-graph-dont-show");
+          nextShowDate.setFullYear(nextShowDate.getFullYear() + 1);
+        } else {
+          // Advance to the next Thursday 08:00.
+          if (nextShowDate.getHours() >= 8) {
+            nextShowDate.setDate(nextShowDate.getDate() + 1);
+          }
+          nextShowDate.setHours(8, 0, 0, 0);
+          while (nextShowDate.getDay() !== 4) {
+            nextShowDate.setDate(nextShowDate.getDate() + 1);
+          }
         }
 
-        var prevSemesters = Object.keys(availableSemesters).sort().reverse();
-        prevSemesters = prevSemesters.slice(prevSemesters.indexOf(currentSemester) + 1);
-        prevSemesters = prevSemesters.slice(0, 3);
+        try {
+          localStorage.setItem(
+            "nextShowThursdayGraphPopup",
+            nextShowDate.valueOf().toString(),
+          );
+        } catch (e) {
+          // localStorage is not available in IE/Edge when running from a local file.
+        }
+      },
+    });
 
-        var prevSemesterLinks = $('<div>');
-        prevSemesters.forEach(function (semester) {
-            var link = $('<a>', {
-                href: '?semester=' + encodeURIComponent(semester),
-                text: semesterFriendlyName(semester)
-            });
-            prevSemesterLinks.append(link, '<br>');
+    return true;
+  }
+
+  function showTechnionScansPopup() {
+    var inSemesterPeriod = Object.keys(availableSemesters).some(
+      function (semester) {
+        var now = Date.now();
+        var item = availableSemesters[semester];
+        var startDate = new Date(item.start);
+        var endDate = new Date(item.end);
+        // Subtract several days from end date for an early notification.
+        endDate.setDate(endDate.getDate() - 7);
+        return now >= startDate && now <= endDate;
+      },
+    );
+    if (inSemesterPeriod) {
+      return false;
+    }
+
+    try {
+      var dontShowDate = localStorage.getItem("dontShowTechnionScansPopup");
+      if (dontShowDate) {
+        var days =
+          (Date.now() - parseInt(dontShowDate, 10)) / (24 * 3600 * 1000);
+        if (days <= 30) {
+          return false;
+        }
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+    }
+
+    BootstrapDialog.show({
+      title: "סריקות לקראת המבחנים",
+      message:
+        '<a href="https://tscans.cf/" target="_blank" rel="noopener" onclick="gtag(\'event\', \'scans-click-logo\')">' +
+        '<img src="https://tscans.cf/scanner_technion.png" width="30%" class="mx-auto d-block">' +
+        "</a><br>" +
+        "לומדים למבחנים? (אם לא, אולי אתם צריכים להתחיל 🙂)<br>" +
+        "מחפשים סריקות של סטודנטים מסמסטרים קודמים ללמוד מהם?<br>" +
+        "קיבלתם ציון טוב, ויש לכם סריקות שיכולות לעזור לאחרים?<br>" +
+        "<br>" +
+        "אתם מוזמנים " +
+        '<a href="https://tscans.cf/" target="_blank" rel="noopener" onclick="gtag(\'event\', \'scans-click-link\')">להיכנס למערכת הסריקות</a>' +
+        ", להיעזר ולעזור.<br>" +
+        "בהצלחה במבחנים!<br>" +
+        "<br>" +
+        '<div class="form-check">' +
+        '<input class="form-check-input" type="checkbox" id="dont-show-technion-scans-popup"> ' +
+        '<label class="form-check-label" for="dont-show-technion-scans-popup">' +
+        "אל תציג את ההודעה שוב" +
+        "</label>" +
+        "</div>",
+      buttons: [
+        {
+          label: "מעבר למערכת הסריקות",
+          cssClass: "btn-primary",
+          action: function (dialog) {
+            gtag("event", "scans-click-button");
+
+            var win = window.open("https://tscans.cf/", "_blank", "noopener");
+            if (win) {
+              win.focus();
+            }
+          },
+        },
+        {
+          label: "סגור",
+          action: function (dialog) {
+            dialog.close();
+          },
+        },
+      ],
+      onhide: function (dialog) {
+        if (document.getElementById("dont-show-technion-scans-popup").checked) {
+          gtag("event", "scans-dont-show");
+
+          try {
+            localStorage.setItem(
+              "dontShowTechnionScansPopup",
+              Date.now().toString(),
+            );
+          } catch (e) {
+            // localStorage is not available in IE/Edge when running from a local file.
+          }
+        }
+      },
+    });
+
+    return true;
+  }
+
+  function navbarInit() {
+    $("#top-navbar-print-section-title").text(
+      semesterFriendlyName(currentSemester),
+    );
+
+    if (!viewingSharedSchedule) {
+      var semesterSelect = $("#top-navbar-semester").find(".dropdown-menu");
+
+      Object.keys(availableSemesters)
+        .sort()
+        .reverse()
+        .forEach(function (semester) {
+          var link = $('<a class="dropdown-item"></a>')
+            .prop("href", "?semester=" + encodeURIComponent(semester))
+            .text(semesterFriendlyName(semester));
+          if (semester === currentSemester) {
+            link.addClass("active");
+          }
+          semesterSelect.append(link);
         });
 
-        prevSemesterLinks = prevSemesterLinks.html();
+      $("#top-navbar-changes").click(function (event) {
+        event.preventDefault();
+
+        gtag("event", "navbar-changes");
 
         BootstrapDialog.show({
-            title: 'פרסום חוות דעת עבור סמסטרים קודמים',
-            message: '<div>' +
-                    'זוכרים את הפעם האחרונה שבה הרכבתם מערכת? את התחושה שהמידע היבש על הקורסים לא מספיק? את החיפושים אחרי מידע נוסף והשאלות בפייסבוק?<br>' +
-                    '<br>' +
-                    'עכשיו תורכם לתרום מניסיונכם לדורות הבאים, והפעם אפשר לעשות את זה ממש פה! עברו לסמסטרים הקודמים והשאירו חוות דעת על קורסים שעשיתם:' +
-                    '<br>' +
-                    prevSemesterLinks +
-                    '<div class="row text-center my-4">' +
-                        '<div class="col-3"><i class="fas fa-3x fa-thumbs-up"></i></div>' +
-                        '<div class="col-3"><i class="fas fa-3x fa-thumbs-down"></i></div>' +
-                        '<div class="col-3"><i class="fas fa-3x fa-feather-alt"></i></div>' +
-                        '<div class="col-3"><i class="fas fa-3x fa-dumbbell"></i></div>' +
-                    '</div>' +
-                '</div>' +
-                '<div class="form-check">' +
-                    '<input class="form-check-input" type="checkbox" id="dont-show-course-feedback-popup"> ' +
-                    '<label class="form-check-label" for="dont-show-course-feedback-popup">' +
-                    'אל תציג את ההודעה שוב' +
-                    '</label>' +
-                '</div>',
-            buttons: [{
-                label: 'סגור',
-                action: function (dialog) {
-                    dialog.close();
-                }
-            }],
-            onhide: function (dialog) {
-                if (document.getElementById('dont-show-course-feedback-popup').checked) {
-                    gtag('event', 'course-feedback-prev-dont-show');
+          title: "שינויים במערכת השעות",
+          message: getPrettyMetadataDiff(),
+          buttons: [
+            {
+              label: "אשר שינויים",
+              cssClass: "btn-primary",
+              action: function (dialog) {
+                gtag(
+                  "event",
+                  metadataDiff ? "metadata-to-current" : "metadata-first-time",
+                );
 
-                    try {
-                        localStorage.setItem('dontShowPrevCourseFeedbackPopup_' + currentSemester, Date.now().toString());
-                    } catch (e) {
-                        // localStorage is not available in IE/Edge when running from a local file.
-                    }
-                }
-            }
-        });
-
-        return true;
-    }
-
-    function showCourseFeedbackPopupThisSemester() {
-        try {
-            var dontShowDate = localStorage.getItem('dontShowThisCourseFeedbackPopup_' + currentSemester);
-            if (dontShowDate) {
-                return false;
-            }
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
-        }
-
-        var courseNumbers = courseButtonList.getCourseNumbers(true);
-        if (courseNumbers.length === 0) {
-            return false;
-        }
-
-        var courses = courseNumbers.map(function (course) {
-            return {
-                course: courseManager.toNewCourseNumber(course),
-                title: courseManager.getTitle(course)
-            };
-        });
-
-        var courseFeedback = new CourseFeedback(null, {});
-        courseFeedback.endOfSemesterFeedbackDialog(courses, {
-            dialogHtml: '<div>' +
-                    'זוכרים את הפעם האחרונה שבה הרכבתם מערכת? את התחושה שהמידע היבש על הקורסים לא מספיק? את החיפושים אחרי מידע נוסף והשאלות בפייסבוק?<br>' +
-                    '<br>' +
-                    'עכשיו תורכם לתרום מניסיונכם לדורות הבאים, והפעם אפשר לעשות את זה ממש פה!' +
-                '</div>' +
-                '<div class="form-check my-3">' +
-                    '<input class="form-check-input" type="checkbox" id="dont-show-course-feedback-popup"> ' +
-                    '<label class="form-check-label" for="dont-show-course-feedback-popup">' +
-                    'אל תציג את ההודעה שוב' +
-                    '</label>' +
-                '</div>',
-            postHtml: null,
-            onHide: function (dialog) {
-                if (document.getElementById('dont-show-course-feedback-popup').checked) {
-                    gtag('event', 'course-feedback-this-dont-show');
-
-                    try {
-                        localStorage.setItem('dontShowThisCourseFeedbackPopup_' + currentSemester, Date.now().toString());
-                    } catch (e) {
-                        // localStorage is not available in IE/Edge when running from a local file.
-                    }
-                } else {
-                    try {
-                        localStorage.removeItem('dontShowThisCourseFeedbackPopup_' + currentSemester);
-                    } catch (e) {
-                        // localStorage is not available in IE/Edge when running from a local file.
-                    }
-                }
+                setMetadataToCurrent();
+                dialog.close();
+              },
             },
-            onSharingDone: function () {
-                gtag('event', 'course-feedback-this-shared');
-
-                try {
-                    localStorage.setItem('dontShowThisCourseFeedbackPopup_' + currentSemester, Date.now().toString());
-                } catch (e) {
-                    // localStorage is not available in IE/Edge when running from a local file.
-                }
-            }
-        });
-
-        return true;
-    }
-
-    function showThursdayGraphPopup() {
-        if (new Date() < new Date('2019-05-09T08:00:00')) {
-            // Don't show before the first graph is available.
-            return false;
-        }
-
-        try {
-            var nextShowDate = localStorage.getItem('nextShowThursdayGraphPopup');
-            if (nextShowDate && Date.now() < nextShowDate) {
-                return false;
-            }
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
-        }
-
-        BootstrapDialog.show({
-            title: 'הגרף השבועי',
-            message: 'בכל יום חמישי אנחנו מפרסמים בעמוד הפייסבוק שלנו גרף מעניין שקשור למקצועות בטכניון.<br>' +
-                '<br>' +
-                '<div class="form-check">' +
-                    '<input class="form-check-input" type="checkbox" id="dont-show-thursday-graph-popup"> ' +
-                    '<label class="form-check-label" for="dont-show-thursday-graph-popup">' +
-                    'אל תציג את ההודעה פעם בשבוע' +
-                    '</label>' +
-                '</div>' +
-                '<br>' +
-                '<div class="facebook-iframe-container"></div>',
-            onshown: function (dialog) {
-                var modalBody = dialog.getModalBody();
-                var width = Math.floor(modalBody.width());
-                var height = 400;
-                var frameSrc = 'https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fcheesefork.technion%2F&tabs=timeline' +
-                    '&width=' + width + '&height=' + height + '&small_header=true&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=863730240682785';
-                var frameElem = $('<iframe style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>')
-                    .attr('src', frameSrc).width(width).height(height);
-                modalBody.find('.facebook-iframe-container').html(frameElem);
+            {
+              label: "סגור",
+              action: function (dialog) {
+                dialog.close();
+              },
             },
-            buttons: [{
-                label: 'סגור',
-                action: function (dialog) {
-                    dialog.close();
-                }
-            }],
-            onhide: function (dialog) {
-                var nextShowDate = new Date();
-
-                if (document.getElementById('dont-show-thursday-graph-popup').checked) {
-                    gtag('event', 'thursday-graph-dont-show');
-                    nextShowDate.setFullYear(nextShowDate.getFullYear() + 1);
-                } else {
-                    // Advance to the next Thursday 08:00.
-                    if (nextShowDate.getHours() >= 8) {
-                        nextShowDate.setDate(nextShowDate.getDate() + 1);
-                    }
-                    nextShowDate.setHours(8, 0, 0, 0);
-                    while (nextShowDate.getDay() !== 4) {
-                        nextShowDate.setDate(nextShowDate.getDate() + 1);
-                    }
-                }
-
-                try {
-                    localStorage.setItem('nextShowThursdayGraphPopup', nextShowDate.valueOf().toString());
-                } catch (e) {
-                    // localStorage is not available in IE/Edge when running from a local file.
-                }
-            }
+          ],
         });
+      });
 
-        return true;
-    }
+      $("#top-navbar-login").click(function (event) {
+        event.preventDefault();
 
-    function showTechnionScansPopup() {
-        var inSemesterPeriod = Object.keys(availableSemesters).some(function (semester) {
-            var now = Date.now();
-            var item = availableSemesters[semester];
-            var startDate = new Date(item.start);
-            var endDate = new Date(item.end);
-            // Subtract several days from end date for an early notification.
-            endDate.setDate(endDate.getDate() - 7);
-            return now >= startDate && now <= endDate;
-        });
-        if (inSemesterPeriod) {
-            return false;
+        gtag("event", "navbar-login");
+
+        if (loginDialog) {
+          loginDialog.open();
+          return;
         }
 
-        try {
-            var dontShowDate = localStorage.getItem('dontShowTechnionScansPopup');
-            if (dontShowDate) {
-                var days = (Date.now() - parseInt(dontShowDate, 10)) / (24 * 3600 * 1000);
-                if (days <= 30) {
-                    return false;
-                }
-            }
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
-        }
+        loginDialog = BootstrapDialog.show({
+          title: "כניסה למערכת",
+          message: $("#firebaseui-auth-container"),
+          buttons: [
+            {
+              label: "סגור",
+              action: function (dialog) {
+                dialog.close();
+              },
+            },
+          ],
+          autodestroy: false,
+        });
+      });
+
+      $("#top-navbar-logout").click(function (event) {
+        event.preventDefault();
+
+        gtag("event", "navbar-logout");
+
+        $(this).find('[data-toggle="tooltip"]').tooltip("hide");
 
         BootstrapDialog.show({
-            title: 'סריקות לקראת המבחנים',
-            message: '<a href="https://tscans.cf/" target="_blank" rel="noopener" onclick="gtag(\'event\', \'scans-click-logo\')">' +
-                    '<img src="https://tscans.cf/scanner_technion.png" width="30%" class="mx-auto d-block">' +
-                '</a><br>' +
-                'לומדים למבחנים? (אם לא, אולי אתם צריכים להתחיל 🙂)<br>' +
-                'מחפשים סריקות של סטודנטים מסמסטרים קודמים ללמוד מהם?<br>' +
-                'קיבלתם ציון טוב, ויש לכם סריקות שיכולות לעזור לאחרים?<br>' +
-                '<br>' +
-                'אתם מוזמנים ' +
-                    '<a href="https://tscans.cf/" target="_blank" rel="noopener" onclick="gtag(\'event\', \'scans-click-link\')">להיכנס למערכת הסריקות</a>' +
-                    ', להיעזר ולעזור.<br>' +
-                'בהצלחה במבחנים!<br>' +
-                '<br>' +
-                '<div class="form-check">' +
-                    '<input class="form-check-input" type="checkbox" id="dont-show-technion-scans-popup"> ' +
-                    '<label class="form-check-label" for="dont-show-technion-scans-popup">' +
-                    'אל תציג את ההודעה שוב' +
-                    '</label>' +
-                '</div>',
-            buttons: [{
-                label: 'מעבר למערכת הסריקות',
-                cssClass: 'btn-primary',
-                action: function (dialog) {
-                    gtag('event', 'scans-click-button');
-
-                    var win = window.open('https://tscans.cf/', '_blank', 'noopener');
-                    if (win) {
-                        win.focus();
-                    }
-                }
-            }, {
-                label: 'סגור',
-                action: function (dialog) {
-                    dialog.close();
-                }
-            }],
-            onhide: function (dialog) {
-                if (document.getElementById('dont-show-technion-scans-popup').checked) {
-                    gtag('event', 'scans-dont-show');
-
-                    try {
-                        localStorage.setItem('dontShowTechnionScansPopup', Date.now().toString());
-                    } catch (e) {
-                        // localStorage is not available in IE/Edge when running from a local file.
-                    }
-                }
-            }
+          title: "יציאה מהמערכת",
+          message: "האם אתם בטוחים שברצונכם לצאת מהמערכת?",
+          buttons: [
+            {
+              label: "יציאה",
+              cssClass: "btn-primary",
+              action: function (dialog) {
+                firebase.auth().signOut();
+                dialog.close();
+              },
+            },
+            {
+              label: "ביטול",
+              action: function (dialog) {
+                dialog.close();
+              },
+            },
+          ],
         });
+      });
 
-        return true;
-    }
-
-    function navbarInit() {
-        $('#top-navbar-print-section-title').text(semesterFriendlyName(currentSemester));
-
-        if (!viewingSharedSchedule) {
-            var semesterSelect = $('#top-navbar-semester').find('.dropdown-menu');
-
-            Object.keys(availableSemesters).sort().reverse().forEach(function (semester) {
-                var link = $('<a class="dropdown-item"></a>')
-                    .prop('href', '?semester=' + encodeURIComponent(semester))
-                    .text(semesterFriendlyName(semester));
-                if (semester === currentSemester) {
-                    link.addClass('active');
-                }
-                semesterSelect.append(link);
-            });
-
-            $('#top-navbar-changes').click(function (event) {
-                event.preventDefault();
-
-                gtag('event', 'navbar-changes');
-
-                BootstrapDialog.show({
-                    title: 'שינויים במערכת השעות',
-                    message: getPrettyMetadataDiff(),
-                    buttons: [{
-                        label: 'אשר שינויים',
-                        cssClass: 'btn-primary',
-                        action: function (dialog) {
-                            gtag('event', metadataDiff ? 'metadata-to-current' : 'metadata-first-time');
-
-                            setMetadataToCurrent();
-                            dialog.close();
-                        }
-                    }, {
-                        label: 'סגור',
-                        action: function (dialog) {
-                            dialog.close();
-                        }
-                    }]
-                });
-            });
-
-            $('#top-navbar-login').click(function (event) {
-                event.preventDefault();
-
-                gtag('event', 'navbar-login');
-
-                if (loginDialog) {
-                    loginDialog.open();
-                    return;
-                }
-
-                loginDialog = BootstrapDialog.show({
-                    title: 'כניסה למערכת',
-                    message: $('#firebaseui-auth-container'),
-                    buttons: [{
-                        label: 'סגור',
-                        action: function (dialog) {
-                            dialog.close();
-                        }
-                    }],
-                    autodestroy: false
-                });
-            });
-
-            $('#top-navbar-logout').click(function (event) {
-                event.preventDefault();
-
-                gtag('event', 'navbar-logout');
-
-                $(this).find('[data-toggle="tooltip"]').tooltip('hide');
-
-                BootstrapDialog.show({
-                    title: 'יציאה מהמערכת',
-                    message: 'האם אתם בטוחים שברצונכם לצאת מהמערכת?',
-                    buttons: [{
-                        label: 'יציאה',
-                        cssClass: 'btn-primary',
-                        action: function (dialog) {
-                            firebase.auth().signOut();
-                            dialog.close();
-                        }
-                    }, {
-                        label: 'ביטול',
-                        action: function (dialog) {
-                            dialog.close();
-                        }
-                    }]
-                });
-            });
-
-            $('#top-navbar-share').click(function (event) {
-                event.preventDefault();
-                if ($(this).find('a').hasClass('disabled')) {
-                    return;
-                }
-
-                gtag('event', 'navbar-share');
-
-                var url = location.protocol + '//' + location.host + location.pathname +
-                    '?semester=' + encodeURIComponent(currentSemester) +
-                    '&uid=' + encodeURIComponent(firebase.auth().currentUser.uid);
-                var urlElement = $('<a target="_blank" rel="noopener">לחצו כאן לפתיחה</a>').prop('href', url);
-                var shareDialogContent = $('<div>הקישור לשיתוף המערכת: </div>').append(urlElement).append('.');
-
-                BootstrapDialog.show({
-                    title: 'שיתוף מערכת',
-                    message: shareDialogContent,
-                    buttons: [{
-                        label: 'העתק קישור',
-                        cssClass: 'btn-primary',
-                        action: function (dialog) {
-                            copyToClipboard(url, function () {
-                                dialog.close();
-                            }, function () {
-                                alert('ההעתקה נכשלה');
-                            });
-                        }
-                    }, {
-                        label: 'סגור',
-                        action: function (dialog) {
-                            dialog.close();
-                        }
-                    }]
-                });
-            });
-
-            $('#top-navbar-undo').click(function (event) {
-                event.preventDefault();
-
-                gtag('event', 'navbar-undo');
-
-                makeUndo();
-            });
-
-            $('#top-navbar-redo').click(function (event) {
-                event.preventDefault();
-
-                gtag('event', 'navbar-redo');
-
-                makeRedo();
-            });
+      $("#top-navbar-share").click(function (event) {
+        event.preventDefault();
+        if ($(this).find("a").hasClass("disabled")) {
+          return;
         }
 
-        $('#top-navbar-export').click(function (event) {
-            event.preventDefault();
+        gtag("event", "navbar-share");
 
-            gtag('event', 'navbar-export');
+        var url =
+          location.protocol +
+          "//" +
+          location.host +
+          location.pathname +
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&uid=" +
+          encodeURIComponent(firebase.auth().currentUser.uid);
+        var urlElement = $(
+          '<a target="_blank" rel="noopener">לחצו כאן לפתיחה</a>',
+        ).prop("href", url);
+        var shareDialogContent = $("<div>הקישור לשיתוף המערכת: </div>")
+          .append(urlElement)
+          .append(".");
 
-            $(this).find('[data-toggle="tooltip"]').tooltip('hide');
-
-            var extraCalendarHeaders = [
-                'NAME:' + semesterFriendlyName(currentSemester),
-
-                // Suggested minimum interval for polling for changes.
-                'REFRESH-INTERVAL;VALUE=DURATION:PT1H',
-                'X-PUBLISHED-TTL:PT1H',
-
-                // Timezone data.
-                'BEGIN:VTIMEZONE',
-                'TZID:Asia/Jerusalem',
-                'X-LIC-LOCATION:Asia/Jerusalem',
-                'BEGIN:DAYLIGHT',
-                'TZNAME:IDT',
-                'TZOFFSETFROM:+0200',
-                'TZOFFSETTO:+0300',
-                'DTSTART:19700327T020000',
-                'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1FR',
-                'END:DAYLIGHT',
-                'BEGIN:STANDARD',
-                'TZNAME:IST',
-                'TZOFFSETFROM:+0300',
-                'TZOFFSETTO:+0200',
-                'DTSTART:19701025T020000',
-                'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
-                'END:STANDARD',
-                'END:VTIMEZONE'
-            ];
-
-            // Generate a unique UID every time to avoid overriding old events.
-            // https://github.com/michael-maltsev/cheese-fork/issues/19
-            var icsCal = ics('cheesefork.cf-' + Date.now(), 'CheeseFork', extraCalendarHeaders, 'Asia/Jerusalem');
-
-            // Schedule.
-            var dateFrom = availableSemesters[currentSemester].start;
-            var dateTo = availableSemesters[currentSemester].end;
-
-            // This is a workaround for a crazy Outlook bug. Recurring events
-            // that start from 26 or 27 of March 2023 are shifted by several
-            // hours.
-            if (dateFrom === '2023-03-21') {
-                dateFrom = '2023-03-19';
-            }
-
-            var calendarEventsUrl = 'https://michael-maltsev.github.io/technion-calendar-events/' + currentSemester + '.json';
-
-            function doExport(daysOff) {
-                courseCalendar.saveAsIcs(icsCal, dateFrom, dateTo, daysOff);
-
-                // Exams.
-                courseButtonList.getCourseNumbers(true).forEach(function (course) {
-                    var general = courseManager.getGeneralInfo(course);
-                    ['מועד א', 'מועד ב'].forEach(function (moed) {
-                        if (general[moed]) {
-                            var parsedDate = courseManager.parseExamDateTime(general[moed]);
-                            if (parsedDate) {
-                                var title = moed + '\' - ' + general['שם מקצוע'];
-                                icsCal.addEvent(title, '', '', parsedDate.start, parsedDate.end);
-                            }
-                        }
-                    });
-                });
-
-                var errorEmptySchedule = function () {
-                    BootstrapDialog.show({
-                        title: 'אופס',
-                        message: 'המערכת ריקה',
-                        size: BootstrapDialog.SIZE_SMALL
-                    });
-                };
-
-                if (viewingSharedSchedule || typeof firebase === 'undefined' || firebase.auth().currentUser === null) {
-                    if (!icsCal.download(semesterFriendlyNameForFileName(currentSemester))) {
-                        errorEmptySchedule();
-                    }
-
-                    return;
-                }
-
-                var calendar = icsCal.build();
-                if (!calendar) {
-                    errorEmptySchedule();
-                    return;
-                }
-
-                var calFilePath = firebase.auth().currentUser.uid + '/' + semesterFriendlyNameForFileName(currentSemester) + '.ics';
-                var calendarUrl = 'https://files.cheesefork.cf/' + calFilePath;
-
-                var exportCalendarDialog = BootstrapDialog.show({
-                    title: ' ייצוא לקובץ iCalendar',
-                    message: 'קובץ ה-iCalendar נשמר בשרת של CheeseFork ומסתנכרן אוטומטית עם המערכת שבניתם בכל פתיחה של חלון זה. ' +
-                        'הקישור קבוע פר משתמש וסמסטר, כך שניתן לייבא את הקישור עצמו לכלי שתומך בכך. ' +
-                        'עבור כל עדכון נוסף מספיק לפתוח את החלון פעם נוספת, במקום הורדה וייבוא בכל פעם של הקובץ. ' +
-                        'שימו לב שהעדכון לא מיידי, ברוב שירותי לוח השנה הסנכרון מתבצע אחת למספר שעות.<br>' +
-                        '<br>' +
-                        'הקישור לקובץ iCalendar: <span class="calendar-link-placeholder">מעדכן את הקובץ בשרת...</span>.',
-                    onshow: function (dialog) {
-                        dialog.getButton('copy-link').disable();
-                    },
-                    buttons: [{
-                        id: 'copy-link',
-                        label: 'העתק קישור',
-                        cssClass: 'btn-primary',
-                        action: function (dialog) {
-                            copyToClipboard(calendarUrl, function () {
-                                dialog.close();
-                            }, function () {
-                                alert('ההעתקה נכשלה');
-                            });
-                        }
-                    }, {
-                        label: 'סגור',
-                        action: function (dialog) {
-                            dialog.close();
-                        }
-                    }]
-                });
-
-                var storageRef = firebaseStorage.ref();
-                var calFileRef = storageRef.child(calFilePath);
-
-                calFileRef.putString(calendar, 'raw', {
-                    // Ask browsers not to cache the request.
-                    // https://stackoverflow.com/q/42788488
-                    // https://stackoverflow.com/q/41938969
-                    cacheControl: 'public, max-age=0'
-                }).then(function (snapshot) {
-                    var urlElement = $('<a target="_blank" rel="noopener">לחצו כאן להורדה</a>').prop('href', calendarUrl);
-                    exportCalendarDialog.getModalBody().find('.calendar-link-placeholder').html(urlElement);
-
-                    exportCalendarDialog.getButton('copy-link').enable();
-                }, function (error) {
-                    alert('Error saving calendar to server: ' + error.message);
-                });
-            }
-
-            $.getJSON(calendarEventsUrl)
-                .done(function (data) {
-                    doExport(data.daysOff || []);
-                })
-                .fail(function (jqXHR) {
-                    if (jqXHR.status === 404) {
-                        doExport([]);
-                    } else {
-                        BootstrapDialog.show({
-                            title: 'שגיאה',
-                            message: 'לא ניתן לטעון את נתוני ימי החופשה עבור הסמסטר הנוכחי.',
-                            size: BootstrapDialog.SIZE_SMALL
-                        });
-                    }
-                });
+        BootstrapDialog.show({
+          title: "שיתוף מערכת",
+          message: shareDialogContent,
+          buttons: [
+            {
+              label: "העתק קישור",
+              cssClass: "btn-primary",
+              action: function (dialog) {
+                copyToClipboard(
+                  url,
+                  function () {
+                    dialog.close();
+                  },
+                  function () {
+                    alert("ההעתקה נכשלה");
+                  },
+                );
+              },
+            },
+            {
+              label: "סגור",
+              action: function (dialog) {
+                dialog.close();
+              },
+            },
+          ],
         });
+      });
+
+      $("#top-navbar-undo").click(function (event) {
+        event.preventDefault();
+
+        gtag("event", "navbar-undo");
+
+        makeUndo();
+      });
+
+      $("#top-navbar-redo").click(function (event) {
+        event.preventDefault();
+
+        gtag("event", "navbar-redo");
+
+        makeRedo();
+      });
     }
 
-    function firebaseInit() {
-        var config = {
-            apiKey: 'AIzaSyAfKPyTM83mkLgdQTdx9YS9UXywiswwIYI',
-            authDomain: 'cheesefork-de9af.firebaseapp.com',
-            databaseURL: 'https://cheesefork-de9af.firebaseio.com',
-            projectId: 'cheesefork-de9af',
-            storageBucket: 'cheesefork-de9af.appspot.com',
-            messagingSenderId: '916559682433'
+    $("#top-navbar-export").click(function (event) {
+      event.preventDefault();
+
+      gtag("event", "navbar-export");
+
+      $(this).find('[data-toggle="tooltip"]').tooltip("hide");
+
+      var extraCalendarHeaders = [
+        "NAME:" + semesterFriendlyName(currentSemester),
+
+        // Suggested minimum interval for polling for changes.
+        "REFRESH-INTERVAL;VALUE=DURATION:PT1H",
+        "X-PUBLISHED-TTL:PT1H",
+
+        // Timezone data.
+        "BEGIN:VTIMEZONE",
+        "TZID:Asia/Jerusalem",
+        "X-LIC-LOCATION:Asia/Jerusalem",
+        "BEGIN:DAYLIGHT",
+        "TZNAME:IDT",
+        "TZOFFSETFROM:+0200",
+        "TZOFFSETTO:+0300",
+        "DTSTART:19700327T020000",
+        "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1FR",
+        "END:DAYLIGHT",
+        "BEGIN:STANDARD",
+        "TZNAME:IST",
+        "TZOFFSETFROM:+0300",
+        "TZOFFSETTO:+0200",
+        "DTSTART:19701025T020000",
+        "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+        "END:STANDARD",
+        "END:VTIMEZONE",
+      ];
+
+      // Generate a unique UID every time to avoid overriding old events.
+      // https://github.com/michael-maltsev/cheese-fork/issues/19
+      var icsCal = ics(
+        "cheesefork.cf-" + Date.now(),
+        "CheeseFork",
+        extraCalendarHeaders,
+        "Asia/Jerusalem",
+      );
+
+      // Schedule.
+      var dateFrom = availableSemesters[currentSemester].start;
+      var dateTo = availableSemesters[currentSemester].end;
+
+      // This is a workaround for a crazy Outlook bug. Recurring events
+      // that start from 26 or 27 of March 2023 are shifted by several
+      // hours.
+      if (dateFrom === "2023-03-21") {
+        dateFrom = "2023-03-19";
+      }
+
+      var calendarEventsUrl =
+        "https://michael-maltsev.github.io/technion-calendar-events/" +
+        currentSemester +
+        ".json";
+
+      function doExport(daysOff) {
+        courseCalendar.saveAsIcs(icsCal, dateFrom, dateTo, daysOff);
+
+        // Exams.
+        courseButtonList.getCourseNumbers(true).forEach(function (course) {
+          var general = courseManager.getGeneralInfo(course);
+          ["מועד א", "מועד ב"].forEach(function (moed) {
+            if (general[moed]) {
+              var parsedDate = courseManager.parseExamDateTime(general[moed]);
+              if (parsedDate) {
+                var title = moed + "' - " + general["שם מקצוע"];
+                icsCal.addEvent(
+                  title,
+                  "",
+                  "",
+                  parsedDate.start,
+                  parsedDate.end,
+                );
+              }
+            }
+          });
+        });
+
+        var errorEmptySchedule = function () {
+          BootstrapDialog.show({
+            title: "אופס",
+            message: "המערכת ריקה",
+            size: BootstrapDialog.SIZE_SMALL,
+          });
         };
-        firebase.initializeApp(config);
 
-        firestoreDb = firebase.firestore();
+        if (
+          viewingSharedSchedule ||
+          typeof firebase === "undefined" ||
+          firebase.auth().currentUser === null
+        ) {
+          if (
+            !icsCal.download(semesterFriendlyNameForFileName(currentSemester))
+          ) {
+            errorEmptySchedule();
+          }
 
-        firebaseStorage = firebase.app().storage('gs://files.cheesefork.cf');
-    }
+          return;
+        }
 
-    function firebaseAuthUIInit(onInitialized) {
-        // FirebaseUI config.
-        var uiConfig = {
-            // Opens IDP Providers sign-in flow in a popup.
-            signInFlow: 'popup',
-            signInOptions: [
-                firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-                firebase.auth.EmailAuthProvider.PROVIDER_ID
-                // I wanted to implement viewing Facebook friends' schedule via the Facebook API,
-                // but they require business verification for the user_friends permission. -_-
-                // https://stackoverflow.com/questions/51089608/business-verification-required-as-part-of-my-app-review
-                /*,
+        var calendar = icsCal.build();
+        if (!calendar) {
+          errorEmptySchedule();
+          return;
+        }
+
+        var calFilePath =
+          firebase.auth().currentUser.uid +
+          "/" +
+          semesterFriendlyNameForFileName(currentSemester) +
+          ".ics";
+        var calendarUrl = "https://files.cheesefork.cf/" + calFilePath;
+
+        var exportCalendarDialog = BootstrapDialog.show({
+          title: " ייצוא לקובץ iCalendar",
+          message:
+            "קובץ ה-iCalendar נשמר בשרת של CheeseFork ומסתנכרן אוטומטית עם המערכת שבניתם בכל פתיחה של חלון זה. " +
+            "הקישור קבוע פר משתמש וסמסטר, כך שניתן לייבא את הקישור עצמו לכלי שתומך בכך. " +
+            "עבור כל עדכון נוסף מספיק לפתוח את החלון פעם נוספת, במקום הורדה וייבוא בכל פעם של הקובץ. " +
+            "שימו לב שהעדכון לא מיידי, ברוב שירותי לוח השנה הסנכרון מתבצע אחת למספר שעות.<br>" +
+            "<br>" +
+            'הקישור לקובץ iCalendar: <span class="calendar-link-placeholder">מעדכן את הקובץ בשרת...</span>.',
+          onshow: function (dialog) {
+            dialog.getButton("copy-link").disable();
+          },
+          buttons: [
+            {
+              id: "copy-link",
+              label: "העתק קישור",
+              cssClass: "btn-primary",
+              action: function (dialog) {
+                copyToClipboard(
+                  calendarUrl,
+                  function () {
+                    dialog.close();
+                  },
+                  function () {
+                    alert("ההעתקה נכשלה");
+                  },
+                );
+              },
+            },
+            {
+              label: "סגור",
+              action: function (dialog) {
+                dialog.close();
+              },
+            },
+          ],
+        });
+
+        var storageRef = firebaseStorage.ref();
+        var calFileRef = storageRef.child(calFilePath);
+
+        calFileRef
+          .putString(calendar, "raw", {
+            // Ask browsers not to cache the request.
+            // https://stackoverflow.com/q/42788488
+            // https://stackoverflow.com/q/41938969
+            cacheControl: "public, max-age=0",
+          })
+          .then(
+            function (snapshot) {
+              var urlElement = $(
+                '<a target="_blank" rel="noopener">לחצו כאן להורדה</a>',
+              ).prop("href", calendarUrl);
+              exportCalendarDialog
+                .getModalBody()
+                .find(".calendar-link-placeholder")
+                .html(urlElement);
+
+              exportCalendarDialog.getButton("copy-link").enable();
+            },
+            function (error) {
+              alert("Error saving calendar to server: " + error.message);
+            },
+          );
+      }
+
+      $.getJSON(calendarEventsUrl)
+        .done(function (data) {
+          doExport(data.daysOff || []);
+        })
+        .fail(function (jqXHR) {
+          if (jqXHR.status === 404) {
+            doExport([]);
+          } else {
+            BootstrapDialog.show({
+              title: "שגיאה",
+              message: "לא ניתן לטעון את נתוני ימי החופשה עבור הסמסטר הנוכחי.",
+              size: BootstrapDialog.SIZE_SMALL,
+            });
+          }
+        });
+    });
+  }
+
+  function firebaseInit() {
+    var config = {
+      apiKey: "AIzaSyCyxZsBibBcN5qq-rqVC9CqvW1bFo5fjnc",
+      authDomain: "cheese-fork-local.firebaseapp.com",
+      projectId: "cheese-fork-local",
+      storageBucket: "cheese-fork-local.firebasestorage.app",
+      messagingSenderId: "1089831905501",
+      appId: "1:1089831905501:web:98aa0b336071e691e4d334",
+      measurementId: "G-GSXTEPRH3K",
+    };
+    firebase.initializeApp(config);
+
+    firestoreDb = firebase.firestore();
+
+    firebaseStorage = firebase.app().storage("gs://files.cheesefork.cf");
+  }
+
+  function firebaseAuthUIInit(onInitialized) {
+    // FirebaseUI config.
+    var uiConfig = {
+      // Opens IDP Providers sign-in flow in a popup.
+      signInFlow: "popup",
+      signInOptions: [
+        firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+        firebase.auth.EmailAuthProvider.PROVIDER_ID,
+        // I wanted to implement viewing Facebook friends' schedule via the Facebook API,
+        // but they require business verification for the user_friends permission. -_-
+        // https://stackoverflow.com/questions/51089608/business-verification-required-as-part-of-my-app-review
+        /*,
                 {
                     provider: firebase.auth.FacebookAuthProvider.PROVIDER_ID,
                     scopes: [
@@ -940,1541 +1084,1797 @@
                         'user_friends'
                     ]
                 }*/
-            ],
-            callbacks: {
-                // Called when the user has been successfully signed in.
-                signInSuccessWithAuthResult: function (authResult) {
-                    if (authResult.user) {
-                        loginDialog.close();
-                    }
-                    // Do not redirect.
-                    return false;
-                }
-            },
-            // Terms of service url.
-            //tosUrl: 'https://policies.google.com/terms',
-            // Privacy policy url.
-            //privacyPolicyUrl: 'https://policies.google.com/privacy',
-            // Disable accountchooser.com which is enabled by default.
-            credentialHelper: firebaseui.auth.CredentialHelper.NONE
-        };
+      ],
+      callbacks: {
+        // Called when the user has been successfully signed in.
+        signInSuccessWithAuthResult: function (authResult) {
+          if (authResult.user) {
+            loginDialog.close();
+          }
+          // Do not redirect.
+          return false;
+        },
+      },
+      // Terms of service url.
+      //tosUrl: 'https://policies.google.com/terms',
+      // Privacy policy url.
+      //privacyPolicyUrl: 'https://policies.google.com/privacy',
+      // Disable accountchooser.com which is enabled by default.
+      credentialHelper: firebaseui.auth.CredentialHelper.NONE,
+    };
 
-        // Initialize the FirebaseUI Widget using Firebase.
-        var firebaseUI = new firebaseui.auth.AuthUI(firebase.auth());
+    // Initialize the FirebaseUI Widget using Firebase.
+    var firebaseUI = new firebaseui.auth.AuthUI(firebase.auth());
 
-        var authInitialized = false;
+    var authInitialized = false;
 
-        // Listen to change in auth state so it displays the correct UI for when
-        // the user is signed in or not.
-        firebase.auth().onAuthStateChanged(function (user) {
-            user ? handleSignedInUser(user) : handleSignedOutUser();
-            if (!authInitialized) {
-                onInitialized();
-                authInitialized = true;
-            } else if (user) {
-                // Slow reload.
-                $('#page-loader').show();
-                stopScheduleWatching();
-                resetSchedule();
-                watchSavedSchedule(function () {
-                    $('#page-loader').hide();
-                });
-            } else {
-                // Fast reload.
-                stopScheduleWatching();
-                resetSchedule();
-                watchSavedSchedule(function () {});
-            }
+    // Listen to change in auth state so it displays the correct UI for when
+    // the user is signed in or not.
+    firebase.auth().onAuthStateChanged(function (user) {
+      user ? handleSignedInUser(user) : handleSignedOutUser();
+      if (!authInitialized) {
+        onInitialized();
+        authInitialized = true;
+      } else if (user) {
+        // Slow reload.
+        $("#page-loader").show();
+        stopScheduleWatching();
+        resetSchedule();
+        watchSavedSchedule(function () {
+          $("#page-loader").hide();
         });
+      } else {
+        // Fast reload.
+        stopScheduleWatching();
+        resetSchedule();
+        watchSavedSchedule(function () {});
+      }
+    });
 
-        function handleSignedInUser(user) {
-            $('#top-navbar-login').addClass('d-none');
-            $('#top-navbar-logout').removeClass('d-none')
-                .find('a').attr('data-original-title', 'מחובר בתור: ' + firestoreDisplayNameDecode(user.displayName || user.email || 'משתמש לא מזוהה'));
-            $('#top-navbar-share').find('a').removeClass('disabled').tooltip('disable');
-        }
-
-        function handleSignedOutUser() {
-            $('#top-navbar-logout').addClass('d-none');
-            $('#top-navbar-login').removeClass('d-none');
-            $('#top-navbar-share').find('a').addClass('disabled').tooltip('enable');
-            firebaseUI.start('#firebaseui-auth-container', uiConfig);
-        }
+    function handleSignedInUser(user) {
+      $("#top-navbar-login").addClass("d-none");
+      $("#top-navbar-logout")
+        .removeClass("d-none")
+        .find("a")
+        .attr(
+          "data-original-title",
+          "מחובר בתור: " +
+            firestoreDisplayNameDecode(
+              user.displayName || user.email || "משתמש לא מזוהה",
+            ),
+        );
+      $("#top-navbar-share")
+        .find("a")
+        .removeClass("disabled")
+        .tooltip("disable");
     }
 
-    function semesterFriendlyName(semester) {
-        var year = parseInt(semester.slice(0, 4), 10);
-        var semesterCode = semester.slice(4);
+    function handleSignedOutUser() {
+      $("#top-navbar-logout").addClass("d-none");
+      $("#top-navbar-login").removeClass("d-none");
+      $("#top-navbar-share").find("a").addClass("disabled").tooltip("enable");
+      firebaseUI.start("#firebaseui-auth-container", uiConfig);
+    }
+  }
 
-        switch (semesterCode) {
-        case '01':
-            return 'חורף ' + year + '-' + (year + 1);
+  function semesterFriendlyName(semester) {
+    var year = parseInt(semester.slice(0, 4), 10);
+    var semesterCode = semester.slice(4);
 
-        case '02':
-            return 'אביב ' + (year + 1);
+    switch (semesterCode) {
+      case "01":
+        return "חורף " + year + "-" + (year + 1);
 
-        case '03':
-            return 'קיץ ' + (year + 1);
+      case "02":
+        return "אביב " + (year + 1);
 
-        default:
-            return semester;
-        }
+      case "03":
+        return "קיץ " + (year + 1);
+
+      default:
+        return semester;
+    }
+  }
+
+  function semesterFriendlyNameForFileName(semester) {
+    var year = parseInt(semester.slice(0, 4), 10);
+    var semesterCode = semester.slice(4);
+
+    switch (semesterCode) {
+      case "01":
+        return "winter-" + year + "-" + (year + 1);
+
+      case "02":
+        return "spring-" + (year + 1);
+
+      case "03":
+        return "summer-" + (year + 1);
+
+      default:
+        return semester;
+    }
+  }
+
+  function updateGeneralInfoLine() {
+    var courses = 0;
+    var points = 0;
+
+    courseButtonList.getCourseNumbers(true).forEach(function (course) {
+      var general = courseManager.getGeneralInfo(course);
+      courses++;
+      points += parseFloat(general["נקודות"]);
+    });
+
+    points = points.toFixed(1).replace(/\.0+$/, "");
+
+    var text;
+    if (courses > 0) {
+      if (courses === 1) {
+        text = "מקצוע אחד";
+      } else {
+        text = courses + " מקצועות";
+      }
+
+      text += ", ";
+      if (points === "1") {
+        text += "נקודה אחת";
+      } else {
+        text += points + " נקודות";
+      }
+    } else {
+      text = "לא נבחרו מקצועות";
     }
 
-    function semesterFriendlyNameForFileName(semester) {
-        var year = parseInt(semester.slice(0, 4), 10);
-        var semesterCode = semester.slice(4);
+    $("#general-info").text(text);
+  }
 
-        switch (semesterCode) {
-        case '01':
-            return 'winter-' + year + '-' + (year + 1);
-
-        case '02':
-            return 'spring-' + (year + 1);
-
-        case '03':
-            return 'summer-' + (year + 1);
-
-        default:
-            return semester;
-        }
+  function selectedCourseSave(course) {
+    var metadataCourseKey = null;
+    var courseData = null;
+    var metadataUpdate = !!metadataDiff;
+    if (metadataUpdate) {
+      metadataCourseKey = currentSemester + "_metadata_" + course;
+      courseData = courseManager.getCourseData(course);
     }
 
-    function updateGeneralInfoLine() {
-        var courses = 0;
-        var points = 0;
+    var semesterCoursesKey = currentSemester + "_courses";
+    var courseKey = currentSemester + "_" + course;
 
-        courseButtonList.getCourseNumbers(true).forEach(function (course) {
-            var general = courseManager.getGeneralInfo(course);
-            courses++;
-            points += parseFloat(general['נקודות']);
-        });
+    // Keep all of the items from currentSavedSession[semesterCoursesKey], even if there
+    // are numbers of courses which don't exist anymore. Use the button list for the order.
+    var courseNumbers = courseButtonList.getCourseNumbers(true);
+    currentSavedSession[semesterCoursesKey] = courseNumbers.concat(
+      $(currentSavedSession[semesterCoursesKey]).not(courseNumbers).get(),
+    );
+    currentSavedSession[courseKey] = {};
 
-        points = points.toFixed(1).replace(/\.0+$/, '');
-
-        var text;
-        if (courses > 0) {
-            if (courses === 1) {
-                text = 'מקצוע אחד';
-            } else {
-                text = courses + ' מקצועות';
-            }
-
-            text += ', ';
-            if (points === '1') {
-                text += 'נקודה אחת';
-            } else {
-                text += points + ' נקודות';
-            }
-        } else {
-            text = 'לא נבחרו מקצועות';
-        }
-
-        $('#general-info').text(text);
-    }
-
-    function selectedCourseSave(course) {
-        var metadataCourseKey = null;
-        var courseData = null;
-        var metadataUpdate = !!metadataDiff;
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
+      input[courseKey] = {};
+      if (metadataUpdate) {
+        input[metadataCourseKey] = courseData;
+      }
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          semesterCoursesKey,
+          JSON.stringify(currentSavedSession[semesterCoursesKey]),
+        );
+        localStorage.removeItem(courseKey);
         if (metadataUpdate) {
-            metadataCourseKey = currentSemester + '_metadata_' + course;
-            courseData = courseManager.getCourseData(course);
+          localStorage.setItem(metadataCourseKey, JSON.stringify(courseData));
         }
-
-        var semesterCoursesKey = currentSemester + '_courses';
-        var courseKey = currentSemester + '_' + course;
-
-        // Keep all of the items from currentSavedSession[semesterCoursesKey], even if there
-        // are numbers of courses which don't exist anymore. Use the button list for the order.
-        var courseNumbers = courseButtonList.getCourseNumbers(true);
-        currentSavedSession[semesterCoursesKey] = courseNumbers.concat(
-            $(currentSavedSession[semesterCoursesKey]).not(courseNumbers).get());
-        currentSavedSession[courseKey] = {};
-
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
-            input[courseKey] = {};
-            if (metadataUpdate) {
-                input[metadataCourseKey] = courseData;
-            }
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(semesterCoursesKey, JSON.stringify(currentSavedSession[semesterCoursesKey]));
-                localStorage.removeItem(courseKey);
-                if (metadataUpdate) {
-                    localStorage.setItem(metadataCourseKey, JSON.stringify(courseData));
-                }
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        onSavedSessionChange();
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
     }
 
-    function coursesOrderSave() {
-        // Save only the course order when reordering via drag-and-drop
-        var semesterCoursesKey = currentSemester + '_courses';
-        var courseNumbers = courseButtonList.getCourseNumbers(true);
-        currentSavedSession[semesterCoursesKey] = courseNumbers.concat(
-            $(currentSavedSession[semesterCoursesKey]).not(courseNumbers).get());
+    onSavedSessionChange();
+  }
 
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(semesterCoursesKey, JSON.stringify(currentSavedSession[semesterCoursesKey]));
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
+  function coursesOrderSave() {
+    // Save only the course order when reordering via drag-and-drop
+    var semesterCoursesKey = currentSemester + "_courses";
+    var courseNumbers = courseButtonList.getCourseNumbers(true);
+    currentSavedSession[semesterCoursesKey] = courseNumbers.concat(
+      $(currentSavedSession[semesterCoursesKey]).not(courseNumbers).get(),
+    );
 
-        onSavedSessionChange();
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          semesterCoursesKey,
+          JSON.stringify(currentSavedSession[semesterCoursesKey]),
+        );
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
     }
 
-    function selectedCourseUnsave(course) {
-        var metadataCourseKey = currentSemester + '_metadata_' + course;
+    onSavedSessionChange();
+  }
 
-        var semesterCoursesKey = currentSemester + '_courses';
-        var courseKey = currentSemester + '_' + course;
+  function selectedCourseUnsave(course) {
+    var metadataCourseKey = currentSemester + "_metadata_" + course;
 
-        currentSavedSession[semesterCoursesKey] = currentSavedSession[semesterCoursesKey].filter(function (item) {
-            return item !== course;
-        });
-        delete currentSavedSession[courseKey];
+    var semesterCoursesKey = currentSemester + "_courses";
+    var courseKey = currentSemester + "_" + course;
 
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[semesterCoursesKey] = firebase.firestore.FieldValue.arrayRemove(course);
-            input[courseKey] = firebase.firestore.FieldValue.delete();
-            input[metadataCourseKey] = firebase.firestore.FieldValue.delete();
-            doc.update(input);
+    currentSavedSession[semesterCoursesKey] = currentSavedSession[
+      semesterCoursesKey
+    ].filter(function (item) {
+      return item !== course;
+    });
+    delete currentSavedSession[courseKey];
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[semesterCoursesKey] =
+        firebase.firestore.FieldValue.arrayRemove(course);
+      input[courseKey] = firebase.firestore.FieldValue.delete();
+      input[metadataCourseKey] = firebase.firestore.FieldValue.delete();
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          semesterCoursesKey,
+          JSON.stringify(currentSavedSession[semesterCoursesKey]),
+        );
+        localStorage.removeItem(courseKey);
+        localStorage.removeItem(metadataCourseKey);
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
+
+    onSavedSessionChange();
+
+    if (metadataDiff && metadataDiff[course]) {
+      delete metadataDiff[course];
+      onMetadataDiffChange();
+    }
+  }
+
+  function selectedLessonSave(course, lessonNumber, lessonType) {
+    var courseKey = currentSemester + "_" + course;
+
+    currentSavedSession[courseKey][lessonType] = lessonNumber;
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[courseKey + "." + lessonType] = lessonNumber;
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          courseKey,
+          JSON.stringify(currentSavedSession[courseKey]),
+        );
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
+
+    onSavedSessionChange();
+  }
+
+  function selectedLessonUnsave(course, lessonNumber, lessonType) {
+    var courseKey = currentSemester + "_" + course;
+
+    delete currentSavedSession[courseKey][lessonType];
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[courseKey + "." + lessonType] =
+        firebase.firestore.FieldValue.delete();
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          courseKey,
+          JSON.stringify(currentSavedSession[courseKey]),
+        );
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
+
+    onSavedSessionChange();
+  }
+
+  function customEventSave(eventId, eventData) {
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+
+    currentSavedSession[semesterCustomEventsKey][eventId] = eventData;
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[semesterCustomEventsKey + "." + eventId] = eventData;
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          semesterCustomEventsKey,
+          JSON.stringify(currentSavedSession[semesterCustomEventsKey]),
+        );
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
+
+    onSavedSessionChange();
+  }
+
+  function customEventUnsave(eventId) {
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+
+    delete currentSavedSession[semesterCustomEventsKey][eventId];
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+      input[semesterCustomEventsKey + "." + eventId] =
+        firebase.firestore.FieldValue.delete();
+      doc.update(input);
+    } else {
+      try {
+        localStorage.setItem(
+          semesterCustomEventsKey,
+          JSON.stringify(currentSavedSession[semesterCustomEventsKey]),
+        );
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
+
+    onSavedSessionChange();
+  }
+
+  function watchSharedSchedule(onLoadedFunc) {
+    var firstDataLoaded = false;
+
+    var doc = firestoreUserDoc(scheduleSharingUserId);
+    doc.onSnapshot(
+      function (result) {
+        var session = result.exists
+          ? savedSessionFromFirestoreData(result.data())
+          : {};
+        setScheduleFromSavedSession(session, !firstDataLoaded);
+
+        if (result.exists && result.data().displayName) {
+          var displayName = firestoreDisplayNameDecode(
+            result.data().displayName,
+          );
+          $("#sharing-user-name").text(displayName);
+          $("#sharing-user-known").removeClass("d-none");
+          $("#sharing-user-unknown").addClass("d-none");
+          document.title =
+            displayName + " - CheeseFork - Your Cheesy Scheduler";
         } else {
-            try {
-                localStorage.setItem(semesterCoursesKey, JSON.stringify(currentSavedSession[semesterCoursesKey]));
-                localStorage.removeItem(courseKey);
-                localStorage.removeItem(metadataCourseKey);
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
+          $("#sharing-user-unknown").removeClass("d-none");
+          $("#sharing-user-known").addClass("d-none");
+          document.title = "CheeseFork - Your Cheesy Scheduler";
         }
 
-        onSavedSessionChange();
+        if (!firstDataLoaded) {
+          onLoadedFunc();
+          firstDataLoaded = true;
+        }
+      },
+      function (error) {
+        alert("Error loading data from server: " + error);
+      },
+    );
+  }
 
-        if (metadataDiff && metadataDiff[course]) {
-            delete metadataDiff[course];
+  function watchSavedSchedule(onLoadedFunc) {
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var firstDataLoaded = false;
+
+      stopScheduleWatching = doc.onSnapshot(
+        function (result) {
+          if (result.metadata.hasPendingWrites) {
+            // The callback was called as a result of a local change, ignore it.
+            // https://stackoverflow.com/questions/50186413/is-firestore-onsnapshot-update-event-due-to-local-client-set
+            return;
+          }
+
+          if (!firstDataLoaded) {
+            // Save name in server for sharing purposes.
+            // Note: Setting displayName serves two purposes, saving the
+            // name and actually creating the document for the semester
+            // if it doesn't exist yet. So set it even if it's null.
+            doc.set(
+              { displayName: firebase.auth().currentUser.displayName },
+              { merge: true },
+            );
+          }
+
+          var session = savedSessionFromFirestoreData(
+            result.exists ? result.data() : {},
+          );
+          setScheduleFromSavedSession(session, !firstDataLoaded);
+
+          if (shouldEnableMetadataDiff()) {
+            var metadata = savedMetadataFromFirestoreData(
+              result.exists ? result.data() : {},
+            );
+            metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
             onMetadataDiffChange();
-        }
-    }
+          } else {
+            metadataDiff = null;
+          }
 
-    function selectedLessonSave(course, lessonNumber, lessonType) {
-        var courseKey = currentSemester + '_' + course;
+          currentSavedSession = session;
 
-        currentSavedSession[courseKey][lessonType] = lessonNumber;
-
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[courseKey + '.' + lessonType] = lessonNumber;
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(courseKey, JSON.stringify(currentSavedSession[courseKey]));
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        onSavedSessionChange();
-    }
-
-    function selectedLessonUnsave(course, lessonNumber, lessonType) {
-        var courseKey = currentSemester + '_' + course;
-
-        delete currentSavedSession[courseKey][lessonType];
-
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[courseKey + '.' + lessonType] = firebase.firestore.FieldValue.delete();
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(courseKey, JSON.stringify(currentSavedSession[courseKey]));
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        onSavedSessionChange();
-    }
-
-    function customEventSave(eventId, eventData) {
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-
-        currentSavedSession[semesterCustomEventsKey][eventId] = eventData;
-
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[semesterCustomEventsKey + '.' + eventId] = eventData;
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(semesterCustomEventsKey, JSON.stringify(currentSavedSession[semesterCustomEventsKey]));
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        onSavedSessionChange();
-    }
-
-    function customEventUnsave(eventId) {
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-
-        delete currentSavedSession[semesterCustomEventsKey][eventId];
-
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-            input[semesterCustomEventsKey + '.' + eventId] = firebase.firestore.FieldValue.delete();
-            doc.update(input);
-        } else {
-            try {
-                localStorage.setItem(semesterCustomEventsKey, JSON.stringify(currentSavedSession[semesterCustomEventsKey]));
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        onSavedSessionChange();
-    }
-
-    function watchSharedSchedule(onLoadedFunc) {
-        var firstDataLoaded = false;
-
-        var doc = firestoreUserDoc(scheduleSharingUserId);
-        doc.onSnapshot(function (result) {
-            var session = result.exists ? savedSessionFromFirestoreData(result.data()) : {};
-            setScheduleFromSavedSession(session, !firstDataLoaded);
-
-            if (result.exists && result.data().displayName) {
-                var displayName = firestoreDisplayNameDecode(result.data().displayName);
-                $('#sharing-user-name').text(displayName);
-                $('#sharing-user-known').removeClass('d-none');
-                $('#sharing-user-unknown').addClass('d-none');
-                document.title = displayName + ' - CheeseFork - Your Cheesy Scheduler';
-            } else {
-                $('#sharing-user-unknown').removeClass('d-none');
-                $('#sharing-user-known').addClass('d-none');
-                document.title = 'CheeseFork - Your Cheesy Scheduler';
-            }
-
-            if (!firstDataLoaded) {
-                onLoadedFunc();
-                firstDataLoaded = true;
-            }
-        }, function (error) {
-            alert('Error loading data from server: ' + error);
-        });
-    }
-
-    function watchSavedSchedule(onLoadedFunc) {
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var firstDataLoaded = false;
-
-            stopScheduleWatching = doc.onSnapshot(function (result) {
-                if (result.metadata.hasPendingWrites) {
-                    // The callback was called as a result of a local change, ignore it.
-                    // https://stackoverflow.com/questions/50186413/is-firestore-onsnapshot-update-event-due-to-local-client-set
-                    return;
-                }
-
-                if (!firstDataLoaded) {
-                    // Save name in server for sharing purposes.
-                    // Note: Setting displayName serves two purposes, saving the
-                    // name and actually creating the document for the semester
-                    // if it doesn't exist yet. So set it even if it's null.
-                    doc.set({ displayName: firebase.auth().currentUser.displayName }, { merge: true });
-                }
-
-                var session = savedSessionFromFirestoreData(result.exists ? result.data() : {});
-                setScheduleFromSavedSession(session, !firstDataLoaded);
-
-                if (shouldEnableMetadataDiff()) {
-                    var metadata = savedMetadataFromFirestoreData(result.exists ? result.data() : {});
-                    metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
-                    onMetadataDiffChange();
-                } else {
-                    metadataDiff = null;
-                }
-
-                currentSavedSession = session;
-
-                if (!firstDataLoaded) {
-                    onSavedSessionReset();
-                    firstDataLoaded = true;
-                    onLoadedFunc();
-                } else {
-                    onSavedSessionChange();
-                }
-            }, function (error) {
-                alert('Error loading data from server: ' + error);
-            });
-        } else {
-            var onStorageEvent = function (e) {
-                var prefix = currentSemester + '_';
-                // Check if the line starts with a required prefix.
-                // https://stackoverflow.com/a/4579228
-                if (e.key.lastIndexOf(prefix, 0) === 0) {
-                    var session = savedSessionFromLocalStorage();
-                    setScheduleFromSavedSession(session, true);
-
-                    if (shouldEnableMetadataDiff()) {
-                        var metadata = savedMetadataFromLocalStorage();
-                        metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
-                        onMetadataDiffChange();
-                    } else {
-                        metadataDiff = null;
-                    }
-
-                    currentSavedSession = session;
-                    onSavedSessionChange();
-                }
-            };
-
-            window.addEventListener('storage', onStorageEvent);
-
-            stopScheduleWatching = function () {
-                window.removeEventListener('storage', onStorageEvent);
-            };
-
-            var session = savedSessionFromLocalStorage();
-            setScheduleFromSavedSession(session, false);
-
-            if (shouldEnableMetadataDiff()) {
-                var metadata = savedMetadataFromLocalStorage();
-                metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
-                onMetadataDiffChange();
-            } else {
-                metadataDiff = null;
-            }
-
-            currentSavedSession = session;
+          if (!firstDataLoaded) {
             onSavedSessionReset();
-
+            firstDataLoaded = true;
             onLoadedFunc();
+          } else {
+            onSavedSessionChange();
+          }
+        },
+        function (error) {
+          alert("Error loading data from server: " + error);
+        },
+      );
+    } else {
+      var onStorageEvent = function (e) {
+        var prefix = currentSemester + "_";
+        // Check if the line starts with a required prefix.
+        // https://stackoverflow.com/a/4579228
+        if (e.key.lastIndexOf(prefix, 0) === 0) {
+          var session = savedSessionFromLocalStorage();
+          setScheduleFromSavedSession(session, true);
+
+          if (shouldEnableMetadataDiff()) {
+            var metadata = savedMetadataFromLocalStorage();
+            metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
+            onMetadataDiffChange();
+          } else {
+            metadataDiff = null;
+          }
+
+          currentSavedSession = session;
+          onSavedSessionChange();
         }
+      };
+
+      window.addEventListener("storage", onStorageEvent);
+
+      stopScheduleWatching = function () {
+        window.removeEventListener("storage", onStorageEvent);
+      };
+
+      var session = savedSessionFromLocalStorage();
+      setScheduleFromSavedSession(session, false);
+
+      if (shouldEnableMetadataDiff()) {
+        var metadata = savedMetadataFromLocalStorage();
+        metadataDiff = metadata ? computeMetadataDiff(metadata) : null;
+        onMetadataDiffChange();
+      } else {
+        metadataDiff = null;
+      }
+
+      currentSavedSession = session;
+      onSavedSessionReset();
+
+      onLoadedFunc();
+    }
+  }
+
+  function savedSessionFromLocalStorage() {
+    var semesterCoursesKey = currentSemester + "_courses";
+    var session = {};
+    try {
+      session[semesterCoursesKey] = JSON.parse(
+        localStorage.getItem(semesterCoursesKey) || "[]",
+      );
+      session[semesterCoursesKey].forEach(function (course) {
+        var courseKey = currentSemester + "_" + course;
+        session[courseKey] = JSON.parse(
+          localStorage.getItem(courseKey) || "{}",
+        );
+      });
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+      session[semesterCoursesKey] = [];
     }
 
-    function savedSessionFromLocalStorage() {
-        var semesterCoursesKey = currentSemester + '_courses';
-        var session = {};
-        try {
-            session[semesterCoursesKey] = JSON.parse(localStorage.getItem(semesterCoursesKey) || '[]');
-            session[semesterCoursesKey].forEach(function (course) {
-                var courseKey = currentSemester + '_' + course;
-                session[courseKey] = JSON.parse(localStorage.getItem(courseKey) || '{}');
-            });
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
-            session[semesterCoursesKey] = [];
-        }
-
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-        try {
-            session[semesterCustomEventsKey] = JSON.parse(localStorage.getItem(semesterCustomEventsKey) || '{}');
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
-            session[semesterCustomEventsKey] = {};
-        }
-
-        return session;
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+    try {
+      session[semesterCustomEventsKey] = JSON.parse(
+        localStorage.getItem(semesterCustomEventsKey) || "{}",
+      );
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
+      session[semesterCustomEventsKey] = {};
     }
 
-    function savedMetadataFromLocalStorage() {
-        var semesterCoursesKey = currentSemester + '_courses';
-        var metadata = {};
-        try {
-            var courses = JSON.parse(localStorage.getItem(semesterCoursesKey) || '[]');
-            courses.forEach(function (course) {
-                var metadataCourseKey = currentSemester + '_metadata_' + course;
-                var courseMetadataEncoded = localStorage.getItem(metadataCourseKey);
-                if (courseMetadataEncoded) {
-                    metadata[course] = JSON.parse(courseMetadataEncoded);
-                }
-            });
+    return session;
+  }
 
-            // If there's at least one course but no metadata at all, that probably means that
-            // the user built the schedule before the feature was introduced.
-            // Return null to handle the case.
-            if (courses.length > 0 && Object.keys(metadata).length === 0) {
-                metadata = null;
-            }
-        } catch (e) {
-            // localStorage is not available in IE/Edge when running from a local file.
+  function savedMetadataFromLocalStorage() {
+    var semesterCoursesKey = currentSemester + "_courses";
+    var metadata = {};
+    try {
+      var courses = JSON.parse(
+        localStorage.getItem(semesterCoursesKey) || "[]",
+      );
+      courses.forEach(function (course) {
+        var metadataCourseKey = currentSemester + "_metadata_" + course;
+        var courseMetadataEncoded = localStorage.getItem(metadataCourseKey);
+        if (courseMetadataEncoded) {
+          metadata[course] = JSON.parse(courseMetadataEncoded);
         }
+      });
 
-        return metadata;
+      // If there's at least one course but no metadata at all, that probably means that
+      // the user built the schedule before the feature was introduced.
+      // Return null to handle the case.
+      if (courses.length > 0 && Object.keys(metadata).length === 0) {
+        metadata = null;
+      }
+    } catch (e) {
+      // localStorage is not available in IE/Edge when running from a local file.
     }
 
-    function savedSessionFromFirestoreData(data) {
-        // Returns only the data relevant to the current semester from data.
-        var semesterCoursesKey = currentSemester + '_courses';
-        var session = {};
-        session[semesterCoursesKey] = data[semesterCoursesKey] || [];
-        session[semesterCoursesKey].forEach(function (course) {
-            var courseKey = currentSemester + '_' + course;
-            session[courseKey] = data[courseKey] || {};
-        });
+    return metadata;
+  }
 
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-        session[semesterCustomEventsKey] = data[semesterCustomEventsKey] || {};
+  function savedSessionFromFirestoreData(data) {
+    // Returns only the data relevant to the current semester from data.
+    var semesterCoursesKey = currentSemester + "_courses";
+    var session = {};
+    session[semesterCoursesKey] = data[semesterCoursesKey] || [];
+    session[semesterCoursesKey].forEach(function (course) {
+      var courseKey = currentSemester + "_" + course;
+      session[courseKey] = data[courseKey] || {};
+    });
 
-        return session;
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+    session[semesterCustomEventsKey] = data[semesterCustomEventsKey] || {};
+
+    return session;
+  }
+
+  function savedMetadataFromFirestoreData(data) {
+    var semesterCoursesKey = currentSemester + "_courses";
+    var metadata = {};
+
+    var courses = data[semesterCoursesKey] || [];
+    courses.forEach(function (course) {
+      var metadataCourseKey = currentSemester + "_metadata_" + course;
+      if (data[metadataCourseKey]) {
+        metadata[course] = data[metadataCourseKey];
+      }
+    });
+
+    // If there's at least one course but no metadata at all, that probably means that
+    // the user built the schedule before the feature was introduced.
+    // Return null to handle the case.
+    if (courses.length > 0 && Object.keys(metadata).length === 0) {
+      metadata = null;
     }
 
-    function savedMetadataFromFirestoreData(data) {
-        var semesterCoursesKey = currentSemester + '_courses';
-        var metadata = {};
+    return metadata;
+  }
 
-        var courses = data[semesterCoursesKey] || [];
-        courses.forEach(function (course) {
-            var metadataCourseKey = currentSemester + '_metadata_' + course;
-            if (data[metadataCourseKey]) {
-                metadata[course] = data[metadataCourseKey];
-            }
-        });
+  function restoreSavedSession(currentSession, sessionToRestore) {
+    var newKeys = [],
+      removeKeys = [];
+    var newMetadataCourses = [];
 
-        // If there's at least one course but no metadata at all, that probably means that
-        // the user built the schedule before the feature was introduced.
-        // Return null to handle the case.
-        if (courses.length > 0 && Object.keys(metadata).length === 0) {
-            metadata = null;
-        }
-
-        return metadata;
+    var semesterCoursesKey = currentSemester + "_courses";
+    var currentCourses = currentSession[semesterCoursesKey];
+    var newCourses = sessionToRestore[semesterCoursesKey];
+    if (JSON.stringify(currentCourses) !== JSON.stringify(newCourses)) {
+      newKeys.push(semesterCoursesKey);
     }
 
-    function restoreSavedSession(currentSession, sessionToRestore) {
-        var newKeys = [], removeKeys = [];
-        var newMetadataCourses = [];
+    currentCourses.forEach(function (course) {
+      if (newCourses.indexOf(course) === -1) {
+        var courseKey = currentSemester + "_" + course;
+        removeKeys.push(courseKey);
 
-        var semesterCoursesKey = currentSemester + '_courses';
-        var currentCourses = currentSession[semesterCoursesKey];
-        var newCourses = sessionToRestore[semesterCoursesKey];
-        if (JSON.stringify(currentCourses) !== JSON.stringify(newCourses)) {
-            newKeys.push(semesterCoursesKey);
+        if (metadataDiff) {
+          var metadataCourseKey = currentSemester + "_metadata_" + course;
+          removeKeys.push(metadataCourseKey);
         }
+      }
+    });
 
-        currentCourses.forEach(function (course) {
-            if (newCourses.indexOf(course) === -1) {
-                var courseKey = currentSemester + '_' + course;
-                removeKeys.push(courseKey);
-
-                if (metadataDiff) {
-                    var metadataCourseKey = currentSemester + '_metadata_' + course;
-                    removeKeys.push(metadataCourseKey);
-                }
-            }
-        });
-
-        newCourses.forEach(function (course) {
-            var courseKey = currentSemester + '_' + course;
-            if (currentCourses.indexOf(course) === -1) {
-                newKeys.push(courseKey);
-                if (metadataDiff) {
-                    newMetadataCourses.push(course);
-                }
-            } else {
-                var currentLessons = currentSession[courseKey];
-                var newLessons = sessionToRestore[courseKey];
-                // Can be different even if object are equal due to key order,
-                // but that's OK, we'll just override the same data.
-                if (JSON.stringify(currentLessons) !== JSON.stringify(newLessons)) {
-                    newKeys.push(courseKey);
-                }
-            }
-        });
-
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-        var currentCustomEvents = currentSession[semesterCustomEventsKey];
-        var newCustomEvents = sessionToRestore[semesterCustomEventsKey];
+    newCourses.forEach(function (course) {
+      var courseKey = currentSemester + "_" + course;
+      if (currentCourses.indexOf(course) === -1) {
+        newKeys.push(courseKey);
+        if (metadataDiff) {
+          newMetadataCourses.push(course);
+        }
+      } else {
+        var currentLessons = currentSession[courseKey];
+        var newLessons = sessionToRestore[courseKey];
         // Can be different even if object are equal due to key order,
         // but that's OK, we'll just override the same data.
-        if (JSON.stringify(currentCustomEvents) !== JSON.stringify(newCustomEvents)) {
-            newKeys.push(semesterCustomEventsKey);
+        if (JSON.stringify(currentLessons) !== JSON.stringify(newLessons)) {
+          newKeys.push(courseKey);
         }
+      }
+    });
 
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
-
-            removeKeys.forEach(function (key) {
-                input[key] = firebase.firestore.FieldValue.delete();
-            });
-
-            newKeys.forEach(function (key) {
-                input[key] = sessionToRestore[key];
-            });
-
-            newMetadataCourses.forEach(function (course) {
-                var metadataCourseKey = currentSemester + '_metadata_' + course;
-                input[metadataCourseKey] = courseManager.getCourseData(course);
-            });
-
-            doc.update(input);
-        } else {
-            try {
-                removeKeys.forEach(function (key) {
-                    localStorage.removeItem(key);
-                });
-
-                newKeys.forEach(function (key) {
-                    localStorage.setItem(key, JSON.stringify(sessionToRestore[key]));
-                });
-
-                newMetadataCourses.forEach(function (course) {
-                    var metadataCourseKey = currentSemester + '_metadata_' + course;
-                    localStorage.setItem(metadataCourseKey, JSON.stringify(courseManager.getCourseData(course)));
-                });
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
-        }
-
-        setScheduleFromSavedSession(sessionToRestore);
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+    var currentCustomEvents = currentSession[semesterCustomEventsKey];
+    var newCustomEvents = sessionToRestore[semesterCustomEventsKey];
+    // Can be different even if object are equal due to key order,
+    // but that's OK, we'll just override the same data.
+    if (
+      JSON.stringify(currentCustomEvents) !== JSON.stringify(newCustomEvents)
+    ) {
+      newKeys.push(semesterCustomEventsKey);
     }
 
-    function setScheduleFromSavedSession(session, restoreScrollPosition) {
-        var scrollTop;
-        if (restoreScrollPosition) {
-            scrollTop = $(window).scrollTop(); // save scroll position
-        }
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
 
-        var semesterCoursesKey = currentSemester + '_courses';
-        courseButtonList.clear();
+      removeKeys.forEach(function (key) {
+        input[key] = firebase.firestore.FieldValue.delete();
+      });
 
-        var schedule = {};
+      newKeys.forEach(function (key) {
+        input[key] = sessionToRestore[key];
+      });
 
-        var courses = session[semesterCoursesKey] || [];
-        courses.forEach(function (course) {
-            if (!schedule[course] && courseManager.doesExist(course)) {
-                courseButtonList.addCourse(course);
+      newMetadataCourses.forEach(function (course) {
+        var metadataCourseKey = currentSemester + "_metadata_" + course;
+        input[metadataCourseKey] = courseManager.getCourseData(course);
+      });
 
-                var courseKey = currentSemester + '_' + course;
-                var lessons = session[courseKey] || {};
-                schedule[course] = lessons;
-            }
+      doc.update(input);
+    } else {
+      try {
+        removeKeys.forEach(function (key) {
+          localStorage.removeItem(key);
         });
 
-        var semesterCustomEventsKey = currentSemester + '_custom_events';
-        var customEvents = session[semesterCustomEventsKey] || {};
-
-        courseCalendar.loadSavedSchedule(schedule, customEvents);
-        updateGeneralInfoLine();
-        courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
-
-        if (restoreScrollPosition) {
-            $(window).scrollTop(scrollTop); // restore scroll position
-        }
-    }
-
-    function resetSchedule() {
-        courseButtonList.clear();
-        courseCalendar.removeAll();
-        updateGeneralInfoLine();
-        courseExamInfo.renderCourses([]);
-        courseSelect.filterReset();
-    }
-
-    function onSavedSessionReset() {
-        savedSessionForUndo = $.extend(true, {}, currentSavedSession); // make a deep copy
-
-        $('#top-navbar-undo').addClass('d-none');
-        $('#top-navbar-redo').addClass('d-none');
-    }
-
-    function onSavedSessionChange() {
-        $('#top-navbar-undo').removeClass('d-none');
-        $('#top-navbar-redo').addClass('d-none');
-    }
-
-    function makeUndo() {
-        restoreSavedSession(currentSavedSession, savedSessionForUndo);
-
-        savedSessionForRedo = currentSavedSession;
-        currentSavedSession = $.extend(true, {}, savedSessionForUndo); // make a deep copy
-
-        $('#top-navbar-undo').addClass('d-none');
-        $('#top-navbar-redo').removeClass('d-none');
-    }
-
-    function makeRedo() {
-        restoreSavedSession(currentSavedSession, savedSessionForRedo);
-
-        currentSavedSession = savedSessionForRedo;
-        savedSessionForRedo = null;
-
-        $('#top-navbar-redo').addClass('d-none');
-        $('#top-navbar-undo').removeClass('d-none');
-    }
-
-    function firestoreAuthenticatedUserDoc() {
-        if (typeof firebase !== 'undefined' && firebase.auth().currentUser !== null) {
-            var doc = firestoreDb.collection('users').doc(firebase.auth().currentUser.uid);
-
-            var semestersWithoutSubCollection = ['201701', '201702', '201703', '201801'];
-            if (semestersWithoutSubCollection.indexOf(currentSemester) === -1) {
-                doc = doc.collection('semesters').doc(currentSemester);
-            }
-
-            return doc;
-        }
-        return null;
-    }
-
-    function firestoreUserDoc(userId) {
-        var doc = firestoreDb.collection('users').doc(userId);
-
-        var semestersWithoutSubCollection = ['201701', '201702', '201703', '201801'];
-        if (semestersWithoutSubCollection.indexOf(currentSemester) === -1) {
-            doc = doc.collection('semesters').doc(currentSemester);
-        }
-
-        return doc;
-    }
-
-    function firestoreDisplayNameDecode(displayName) {
-        // For some reason, the ' symbol is encoded as &#39;.
-        return displayName.replace('&#39;', '\'');
-    }
-
-    function shouldEnableMetadataDiff() {
-        // Only enable the feature for last four semesters.
-        // Only the last three are updated, and extra semester to give time to see the most recent changes.
-        var lastFourSemesters = Object.keys(availableSemesters).sort().reverse().slice(0, 4);
-        return lastFourSemesters.indexOf(currentSemester) !== -1;
-    }
-
-    function computeMetadataDiff(metadata) {
-        var diff = {};
-
-        Object.keys(metadata).forEach(function (course) {
-            var courseMetadata = metadata[course];
-
-            if (!courseManager.doesExist(course)) {
-                diff[course] = {
-                    exists: false,
-                    general: courseMetadata.general
-                };
-                return;
-            }
-
-            var generalCourseDiff = computeCourseGeneralMetadataDiff(courseMetadata.general, courseManager.getGeneralInfo(course));
-            var scheduleCourseDiff = computeCourseScheduleMetadataDiff(courseMetadata.schedule, courseManager.getSchedule(course));
-            if (generalCourseDiff.length > 0 || scheduleCourseDiff.length > 0) {
-                diff[course] = {
-                    exists: true,
-                    changes: generalCourseDiff.concat(scheduleCourseDiff)
-                };
-            }
+        newKeys.forEach(function (key) {
+          localStorage.setItem(key, JSON.stringify(sessionToRestore[key]));
         });
 
-        return diff;
+        newMetadataCourses.forEach(function (course) {
+          var metadataCourseKey = currentSemester + "_metadata_" + course;
+          localStorage.setItem(
+            metadataCourseKey,
+            JSON.stringify(courseManager.getCourseData(course)),
+          );
+        });
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
     }
 
-    function computeCourseGeneralMetadataDiff(oldGeneral, newGeneral) {
-        var keyOrder = [
-            'פקולטה',
-            'מסגרת לימודים',
-            'שם מקצוע',
-            'מספר מקצוע',
-            'אתר הקורס', // old format
-            'נקודות',
-            'הרצאה', // old format
-            'תרגיל', // old format
-            'מעבדה', // old format
-            'סמינר/פרויקט', // old format
-            'סילבוס',
-            'מקצועות קדם',
-            'מקצועות צמודים',
-            'מקצועות ללא זיכוי נוסף',
-            'מקצועות ללא זיכוי נוסף (מכילים)',
-            'מקצועות ללא זיכוי נוסף (מוכלים)',
-            'מקצועות זהים', // old format
-            'עבור לסמסטר', // old format
-            'אחראים',
-            'הערות',
-            'מועד הבחינה', // old format
-            'בוחן מועד א',
-            'בוחן מועד ב',
-            'בוחן מועד ג',
-            'בוחן מועד ד',
-            'בוחן מועד ה',
-            'בוחן מועד ו',
-            'מועד א',
-            'מועד ב',
-            'מועד ג',
-            'מיקום' // old format
-        ];
-        var compareFunction = function (a, b) {
-            var aIndex = (keyOrder.indexOf(a) + 1) || Number.MAX_VALUE;
-            var bIndex = (keyOrder.indexOf(b) + 1) || Number.MAX_VALUE;
-            if (aIndex !== bIndex) {
-                return aIndex - bIndex;
-            }
+    setScheduleFromSavedSession(sessionToRestore);
+  }
 
-            return a.localeCompare(b);
+  function setScheduleFromSavedSession(session, restoreScrollPosition) {
+    var scrollTop;
+    if (restoreScrollPosition) {
+      scrollTop = $(window).scrollTop(); // save scroll position
+    }
+
+    var semesterCoursesKey = currentSemester + "_courses";
+    courseButtonList.clear();
+
+    var schedule = {};
+
+    var courses = session[semesterCoursesKey] || [];
+    courses.forEach(function (course) {
+      if (!schedule[course] && courseManager.doesExist(course)) {
+        courseButtonList.addCourse(course);
+
+        var courseKey = currentSemester + "_" + course;
+        var lessons = session[courseKey] || {};
+        schedule[course] = lessons;
+      }
+    });
+
+    var semesterCustomEventsKey = currentSemester + "_custom_events";
+    var customEvents = session[semesterCustomEventsKey] || {};
+
+    courseCalendar.loadSavedSchedule(schedule, customEvents);
+    updateGeneralInfoLine();
+    courseExamInfo.renderCourses(courseButtonList.getCourseNumbers(true));
+
+    if (restoreScrollPosition) {
+      $(window).scrollTop(scrollTop); // restore scroll position
+    }
+  }
+
+  function resetSchedule() {
+    courseButtonList.clear();
+    courseCalendar.removeAll();
+    updateGeneralInfoLine();
+    courseExamInfo.renderCourses([]);
+    courseSelect.filterReset();
+  }
+
+  function onSavedSessionReset() {
+    savedSessionForUndo = $.extend(true, {}, currentSavedSession); // make a deep copy
+
+    $("#top-navbar-undo").addClass("d-none");
+    $("#top-navbar-redo").addClass("d-none");
+  }
+
+  function onSavedSessionChange() {
+    $("#top-navbar-undo").removeClass("d-none");
+    $("#top-navbar-redo").addClass("d-none");
+  }
+
+  function makeUndo() {
+    restoreSavedSession(currentSavedSession, savedSessionForUndo);
+
+    savedSessionForRedo = currentSavedSession;
+    currentSavedSession = $.extend(true, {}, savedSessionForUndo); // make a deep copy
+
+    $("#top-navbar-undo").addClass("d-none");
+    $("#top-navbar-redo").removeClass("d-none");
+  }
+
+  function makeRedo() {
+    restoreSavedSession(currentSavedSession, savedSessionForRedo);
+
+    currentSavedSession = savedSessionForRedo;
+    savedSessionForRedo = null;
+
+    $("#top-navbar-redo").addClass("d-none");
+    $("#top-navbar-undo").removeClass("d-none");
+  }
+
+  function firestoreAuthenticatedUserDoc() {
+    if (
+      typeof firebase !== "undefined" &&
+      firebase.auth().currentUser !== null
+    ) {
+      var doc = firestoreDb
+        .collection("users")
+        .doc(firebase.auth().currentUser.uid);
+
+      var semestersWithoutSubCollection = [
+        "201701",
+        "201702",
+        "201703",
+        "201801",
+      ];
+      if (semestersWithoutSubCollection.indexOf(currentSemester) === -1) {
+        doc = doc.collection("semesters").doc(currentSemester);
+      }
+
+      return doc;
+    }
+    return null;
+  }
+
+  function firestoreUserDoc(userId) {
+    var doc = firestoreDb.collection("users").doc(userId);
+
+    var semestersWithoutSubCollection = [
+      "201701",
+      "201702",
+      "201703",
+      "201801",
+    ];
+    if (semestersWithoutSubCollection.indexOf(currentSemester) === -1) {
+      doc = doc.collection("semesters").doc(currentSemester);
+    }
+
+    return doc;
+  }
+
+  function firestoreDisplayNameDecode(displayName) {
+    // For some reason, the ' symbol is encoded as &#39;.
+    return displayName.replace("&#39;", "'");
+  }
+
+  function shouldEnableMetadataDiff() {
+    // Only enable the feature for last four semesters.
+    // Only the last three are updated, and extra semester to give time to see the most recent changes.
+    var lastFourSemesters = Object.keys(availableSemesters)
+      .sort()
+      .reverse()
+      .slice(0, 4);
+    return lastFourSemesters.indexOf(currentSemester) !== -1;
+  }
+
+  function computeMetadataDiff(metadata) {
+    var diff = {};
+
+    Object.keys(metadata).forEach(function (course) {
+      var courseMetadata = metadata[course];
+
+      if (!courseManager.doesExist(course)) {
+        diff[course] = {
+          exists: false,
+          general: courseMetadata.general,
         };
+        return;
+      }
 
-        var keyExclude = {
-            'אתר הקורס': true,
-            'עבור לסמסטר': true,
-            'מיקום': true
+      var generalCourseDiff = computeCourseGeneralMetadataDiff(
+        courseMetadata.general,
+        courseManager.getGeneralInfo(course),
+      );
+      var scheduleCourseDiff = computeCourseScheduleMetadataDiff(
+        courseMetadata.schedule,
+        courseManager.getSchedule(course),
+      );
+      if (generalCourseDiff.length > 0 || scheduleCourseDiff.length > 0) {
+        diff[course] = {
+          exists: true,
+          changes: generalCourseDiff.concat(scheduleCourseDiff),
         };
+      }
+    });
 
-        var oldText = '';
-        Object.keys(oldGeneral).sort(compareFunction).forEach(function (key) {
-            if (!keyExclude[key] && oldGeneral[key] !== newGeneral[key] && oldGeneral[key]) {
-                oldText += key + ': ' + oldGeneral[key] + '\n';
-            }
-        });
+    return diff;
+  }
 
-        var newText = '';
-        Object.keys(newGeneral).sort(compareFunction).forEach(function (key) {
-            if (!keyExclude[key] && newGeneral[key] !== oldGeneral[key] && newGeneral[key]) {
-                newText += key + ': ' + newGeneral[key] + '\n';
-            }
-        });
+  function computeCourseGeneralMetadataDiff(oldGeneral, newGeneral) {
+    var keyOrder = [
+      "פקולטה",
+      "מסגרת לימודים",
+      "שם מקצוע",
+      "מספר מקצוע",
+      "אתר הקורס", // old format
+      "נקודות",
+      "הרצאה", // old format
+      "תרגיל", // old format
+      "מעבדה", // old format
+      "סמינר/פרויקט", // old format
+      "סילבוס",
+      "מקצועות קדם",
+      "מקצועות צמודים",
+      "מקצועות ללא זיכוי נוסף",
+      "מקצועות ללא זיכוי נוסף (מכילים)",
+      "מקצועות ללא זיכוי נוסף (מוכלים)",
+      "מקצועות זהים", // old format
+      "עבור לסמסטר", // old format
+      "אחראים",
+      "הערות",
+      "מועד הבחינה", // old format
+      "בוחן מועד א",
+      "בוחן מועד ב",
+      "בוחן מועד ג",
+      "בוחן מועד ד",
+      "בוחן מועד ה",
+      "בוחן מועד ו",
+      "מועד א",
+      "מועד ב",
+      "מועד ג",
+      "מיקום", // old format
+    ];
+    var compareFunction = function (a, b) {
+      var aIndex = keyOrder.indexOf(a) + 1 || Number.MAX_VALUE;
+      var bIndex = keyOrder.indexOf(b) + 1 || Number.MAX_VALUE;
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex;
+      }
 
-        if (oldText === '' && newText === '') {
-            return [];
+      return a.localeCompare(b);
+    };
+
+    var keyExclude = {
+      "אתר הקורס": true,
+      "עבור לסמסטר": true,
+      מיקום: true,
+    };
+
+    var oldText = "";
+    Object.keys(oldGeneral)
+      .sort(compareFunction)
+      .forEach(function (key) {
+        if (
+          !keyExclude[key] &&
+          oldGeneral[key] !== newGeneral[key] &&
+          oldGeneral[key]
+        ) {
+          oldText += key + ": " + oldGeneral[key] + "\n";
         }
+      });
 
-        return [{
-            title: 'מידע כללי',
-            old: oldText.trim(),
-            new: newText.trim()
-        }];
+    var newText = "";
+    Object.keys(newGeneral)
+      .sort(compareFunction)
+      .forEach(function (key) {
+        if (
+          !keyExclude[key] &&
+          newGeneral[key] !== oldGeneral[key] &&
+          newGeneral[key]
+        ) {
+          newText += key + ": " + newGeneral[key] + "\n";
+        }
+      });
+
+    if (oldText === "" && newText === "") {
+      return [];
     }
 
-    function computeCourseScheduleMetadataDiff(oldSchedule, newSchedule) {
-        var diff = [];
-        var scheduleGroups = {};
+    return [
+      {
+        title: "מידע כללי",
+        old: oldText.trim(),
+        new: newText.trim(),
+      },
+    ];
+  }
 
-        var oldScheduleByGroups = scheduleToGroupOfTexts(oldSchedule);
-        var newScheduleByGroups = scheduleToGroupOfTexts(newSchedule);
+  function computeCourseScheduleMetadataDiff(oldSchedule, newSchedule) {
+    var diff = [];
+    var scheduleGroups = {};
 
-        Object.keys(scheduleGroups).sort().forEach(function (typeAndNumber) {
-            if (oldScheduleByGroups[typeAndNumber] !== newScheduleByGroups[typeAndNumber]) {
-                diff.push({
-                    title: typeAndNumber,
-                    old: (oldScheduleByGroups[typeAndNumber] || '').trim(),
-                    new: (newScheduleByGroups[typeAndNumber] || '').trim()
-                });
+    var oldScheduleByGroups = scheduleToGroupOfTexts(oldSchedule);
+    var newScheduleByGroups = scheduleToGroupOfTexts(newSchedule);
+
+    Object.keys(scheduleGroups)
+      .sort()
+      .forEach(function (typeAndNumber) {
+        if (
+          oldScheduleByGroups[typeAndNumber] !==
+          newScheduleByGroups[typeAndNumber]
+        ) {
+          diff.push({
+            title: typeAndNumber,
+            old: (oldScheduleByGroups[typeAndNumber] || "").trim(),
+            new: (newScheduleByGroups[typeAndNumber] || "").trim(),
+          });
+        }
+      });
+
+    return diff;
+
+    function scheduleToGroupOfTexts(schedule) {
+      var keyOrder = ["מרצה/מתרגל", "יום", "שעה", "בניין", "חדר"];
+      var compareFunction = function (a, b) {
+        var aIndex = keyOrder.indexOf(a) + 1 || Number.MAX_VALUE;
+        var bIndex = keyOrder.indexOf(b) + 1 || Number.MAX_VALUE;
+        if (aIndex !== bIndex) {
+          return aIndex - bIndex;
+        }
+
+        return a.localeCompare(b);
+      };
+
+      var lessonsAdded = {};
+
+      var scheduleByGroups = {};
+      schedule.forEach(function (lesson) {
+        if (
+          lessonsAdded[lesson["מס."]] &&
+          lessonsAdded[lesson["מס."]] !== lesson["קבוצה"]
+        ) {
+          return;
+        }
+
+        var lessonText = "";
+        Object.keys(lesson)
+          .sort(compareFunction)
+          .forEach(function (key) {
+            if (
+              key !== "קבוצה" &&
+              key !== "מס." &&
+              key !== "סוג" &&
+              lesson[key]
+            ) {
+              lessonText += key + ": " + lesson[key] + "\n";
             }
+          });
+
+        var typeAndNumber = courseManager.getLessonTypeAndNumber(lesson);
+        if (!scheduleByGroups[typeAndNumber]) {
+          scheduleByGroups[typeAndNumber] = "";
+        }
+
+        scheduleByGroups[typeAndNumber] += lessonText + "\n";
+
+        lessonsAdded[lesson["מס."]] = lesson["קבוצה"];
+        scheduleGroups[typeAndNumber] = true;
+      });
+
+      return scheduleByGroups;
+    }
+  }
+
+  function getPrettyMetadataDiff() {
+    var result;
+
+    if (metadataDiff) {
+      result = $('<div class="course-metadata-diff-container"></div>');
+
+      Object.keys(metadataDiff)
+        .sort()
+        .forEach(function (course) {
+          var courseDiff = metadataDiff[course];
+          var general, courseTitle;
+          if (courseDiff.exists) {
+            general = courseManager.getGeneralInfo(course);
+            courseTitle = general["מספר מקצוע"] + " - " + general["שם מקצוע"];
+            result.append($("<h3>").text(courseTitle));
+
+            courseDiff.changes.forEach(function (diff) {
+              result.append($("<h5>").text(diff.title));
+
+              var jsDiff = JsDiff.diffWords(diff.old, diff.new);
+              jsDiff.forEach(function (part) {
+                var partElement = $("<span>").text(part.value);
+                if (part.added) {
+                  partElement.addClass("course-metadata-diff-new");
+                } else if (part.removed) {
+                  partElement.addClass("course-metadata-diff-old");
+                }
+
+                result.append(partElement);
+              });
+            });
+          } else {
+            general = courseDiff.general;
+            courseTitle = general["מספר מקצוע"] + " - " + general["שם מקצוע"];
+            result
+              .append($("<h3>").text(courseTitle))
+              .append($("<span>").text("הקורס לא קיים יותר"));
+          }
+        });
+    } else {
+      result = $("<div>");
+
+      var explanation =
+        "מעכשיו תוכלו להתעדכן בכל השינויים שקורים בקורסים שלכם דרך CheeseFork! " +
+        "לחצו על הכפתור <b>אשר שינויים</b>, ובכל פעם שיהיו שינויים באחד הקורסים שאתם רשומים אליו, אתם תראו אותם פה בחלון השינויים.";
+
+      result.html(explanation);
+    }
+
+    return result;
+  }
+
+  function setMetadataToCurrent() {
+    var deletedCourses = [];
+    if (metadataDiff) {
+      deletedCourses = Object.keys(metadataDiff).filter(function (course) {
+        return !metadataDiff[course].exists;
+      });
+    }
+
+    var semesterCoursesKey = currentSemester + "_courses";
+    if (deletedCourses.length > 0) {
+      currentSavedSession[semesterCoursesKey] = $(
+        currentSavedSession[semesterCoursesKey],
+      )
+        .not(deletedCourses)
+        .get();
+    }
+
+    deletedCourses.forEach(function (course) {
+      var courseKey = currentSemester + "_" + course;
+      delete currentSavedSession[courseKey];
+    });
+
+    var courseNumbers = courseButtonList.getCourseNumbers(true);
+
+    var doc = firestoreAuthenticatedUserDoc();
+    if (doc) {
+      var input = {};
+
+      courseNumbers.forEach(function (course) {
+        var metadataCourseKey = currentSemester + "_metadata_" + course;
+        var courseData = courseManager.getCourseData(course);
+        input[metadataCourseKey] = courseData;
+      });
+
+      if (deletedCourses.length > 0) {
+        input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
+      }
+
+      deletedCourses.forEach(function (course) {
+        var courseKey = currentSemester + "_" + course;
+        input[courseKey] = firebase.firestore.FieldValue.delete();
+
+        var metadataCourseKey = currentSemester + "_metadata_" + course;
+        input[metadataCourseKey] = firebase.firestore.FieldValue.delete();
+      });
+
+      doc.update(input);
+    } else {
+      try {
+        courseNumbers.forEach(function (course) {
+          var metadataCourseKey = currentSemester + "_metadata_" + course;
+          var courseData = courseManager.getCourseData(course);
+          localStorage.setItem(metadataCourseKey, JSON.stringify(courseData));
         });
 
-        return diff;
-
-        function scheduleToGroupOfTexts(schedule) {
-            var keyOrder = [
-                'מרצה/מתרגל',
-                'יום',
-                'שעה',
-                'בניין',
-                'חדר'
-            ];
-            var compareFunction = function (a, b) {
-                var aIndex = (keyOrder.indexOf(a) + 1) || Number.MAX_VALUE;
-                var bIndex = (keyOrder.indexOf(b) + 1) || Number.MAX_VALUE;
-                if (aIndex !== bIndex) {
-                    return aIndex - bIndex;
-                }
-
-                return a.localeCompare(b);
-            };
-
-            var lessonsAdded = {};
-
-            var scheduleByGroups = {};
-            schedule.forEach(function (lesson) {
-                if (lessonsAdded[lesson['מס.']] && lessonsAdded[lesson['מס.']] !== lesson['קבוצה']) {
-                    return;
-                }
-
-                var lessonText = '';
-                Object.keys(lesson).sort(compareFunction).forEach(function (key) {
-                    if (key !== 'קבוצה' &&
-                        key !== 'מס.' &&
-                        key !== 'סוג' &&
-                        lesson[key]) {
-                        lessonText += key + ': ' + lesson[key] + '\n';
-                    }
-                });
-
-                var typeAndNumber = courseManager.getLessonTypeAndNumber(lesson);
-                if (!scheduleByGroups[typeAndNumber]) {
-                    scheduleByGroups[typeAndNumber] = '';
-                }
-
-                scheduleByGroups[typeAndNumber] += lessonText + '\n';
-
-                lessonsAdded[lesson['מס.']] = lesson['קבוצה'];
-                scheduleGroups[typeAndNumber] = true;
-            });
-
-            return scheduleByGroups;
-        }
-    }
-
-    function getPrettyMetadataDiff() {
-        var result;
-
-        if (metadataDiff) {
-            result = $('<div class="course-metadata-diff-container"></div>');
-
-            Object.keys(metadataDiff).sort().forEach(function (course) {
-                var courseDiff = metadataDiff[course];
-                var general, courseTitle;
-                if (courseDiff.exists) {
-                    general = courseManager.getGeneralInfo(course);
-                    courseTitle = general['מספר מקצוע'] + ' - ' + general['שם מקצוע'];
-                    result.append($('<h3>').text(courseTitle));
-
-                    courseDiff.changes.forEach(function (diff) {
-                        result.append($('<h5>').text(diff.title));
-
-                        var jsDiff = JsDiff.diffWords(diff.old, diff.new);
-                        jsDiff.forEach(function (part) {
-                            var partElement = $('<span>').text(part.value);
-                            if (part.added) {
-                                partElement.addClass('course-metadata-diff-new');
-                            } else if (part.removed) {
-                                partElement.addClass('course-metadata-diff-old');
-                            }
-
-                            result.append(partElement);
-                        });
-                    });
-                } else {
-                    general = courseDiff.general;
-                    courseTitle = general['מספר מקצוע'] + ' - ' + general['שם מקצוע'];
-                    result.append($('<h3>').text(courseTitle)).append($('<span>').text('הקורס לא קיים יותר'));
-                }
-            });
-        } else {
-            result = $('<div>');
-
-            var explanation = 'מעכשיו תוכלו להתעדכן בכל השינויים שקורים בקורסים שלכם דרך CheeseFork! ' +
-                'לחצו על הכפתור <b>אשר שינויים</b>, ובכל פעם שיהיו שינויים באחד הקורסים שאתם רשומים אליו, אתם תראו אותם פה בחלון השינויים.';
-
-            result.html(explanation);
-        }
-
-        return result;
-    }
-
-    function setMetadataToCurrent() {
-        var deletedCourses = [];
-        if (metadataDiff) {
-            deletedCourses = Object.keys(metadataDiff).filter(function (course) {
-                return !metadataDiff[course].exists;
-            });
-        }
-
-        var semesterCoursesKey = currentSemester + '_courses';
         if (deletedCourses.length > 0) {
-            currentSavedSession[semesterCoursesKey] = $(currentSavedSession[semesterCoursesKey]).not(deletedCourses).get();
+          localStorage.setItem(
+            semesterCoursesKey,
+            JSON.stringify(currentSavedSession[semesterCoursesKey]),
+          );
         }
 
         deletedCourses.forEach(function (course) {
-            var courseKey = currentSemester + '_' + course;
-            delete currentSavedSession[courseKey];
+          var courseKey = currentSemester + "_" + course;
+          localStorage.removeItem(courseKey);
+
+          var metadataCourseKey = currentSemester + "_metadata_" + course;
+          localStorage.removeItem(metadataCourseKey);
         });
+      } catch (e) {
+        // localStorage is not available in IE/Edge when running from a local file.
+      }
+    }
 
-        var courseNumbers = courseButtonList.getCourseNumbers(true);
+    metadataDiff = {};
+    onMetadataDiffChange();
+  }
 
-        var doc = firestoreAuthenticatedUserDoc();
-        if (doc) {
-            var input = {};
+  function onMetadataDiffChange() {
+    var badgeCount = 0;
 
-            courseNumbers.forEach(function (course) {
-                var metadataCourseKey = currentSemester + '_metadata_' + course;
-                var courseData = courseManager.getCourseData(course);
-                input[metadataCourseKey] = courseData;
-            });
+    if (metadataDiff) {
+      var diffCourses = Object.keys(metadataDiff);
+      if (diffCourses.length > 0) {
+        badgeCount = diffCourses.reduce(function (accumulator, course) {
+          var diff = metadataDiff[course];
+          return accumulator + (diff.exists ? diff.changes.length : 1);
+        }, 0);
+      }
+    } else {
+      // If !metadataDiff, that probably means that
+      // the user built the schedule before the feature was introduced.
+      badgeCount = 1;
+    }
 
-            if (deletedCourses.length > 0) {
-                input[semesterCoursesKey] = currentSavedSession[semesterCoursesKey];
-            }
+    if (badgeCount > 0) {
+      $("#top-navbar-changes")
+        .removeClass("d-none")
+        .find(".unread-count-badge")
+        .text(badgeCount);
+      $("#top-navbar .navbar-toggler .unread-count-badge")
+        .text(badgeCount)
+        .removeClass("d-none");
+    } else {
+      $("#top-navbar-changes").addClass("d-none");
+      $("#top-navbar .navbar-toggler .unread-count-badge").addClass("d-none");
+    }
+  }
 
-            deletedCourses.forEach(function (course) {
-                var courseKey = currentSemester + '_' + course;
-                input[courseKey] = firebase.firestore.FieldValue.delete();
+  // https://stackoverflow.com/a/30810322
+  function copyToClipboard(text, onSuccess, onFailure) {
+    if (!navigator.clipboard) {
+      fallbackCopyTextToClipboard(text);
+      return;
+    }
+    // eslint-disable-next-line compat/compat
+    navigator.clipboard.writeText(text).then(
+      function () {
+        onSuccess();
+      },
+      function (err) {
+        onFailure();
+      },
+    );
 
-                var metadataCourseKey = currentSemester + '_metadata_' + course;
-                input[metadataCourseKey] = firebase.firestore.FieldValue.delete();
-            });
+    function fallbackCopyTextToClipboard(text) {
+      var textArea = document.createElement("textarea");
+      textArea.value = text;
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
 
-            doc.update(input);
+      var successful = false;
+      try {
+        successful = document.execCommand("copy");
+      } catch (err) {
+        // We tried...
+      }
+
+      document.body.removeChild(textArea);
+
+      if (successful) {
+        onSuccess();
+      } else {
+        onFailure();
+      }
+    }
+  }
+
+  function crawlersInfo() {
+    var courseParameter = getParameterByName("course");
+    var staffParameter = getParameterByName("staff");
+    var roomParameter = getParameterByName("room");
+
+    if (
+      courseParameter === null &&
+      staffParameter === null &&
+      roomParameter === null
+    ) {
+      return false;
+    }
+
+    var content = $('<div class="col-md-12"></div>');
+    var title = semesterFriendlyName(currentSemester) + " - CheeseFork";
+
+    if (courseParameter !== null) {
+      if (courseManager.doesExist(courseParameter)) {
+        crawlersMakeCourseContent(content, courseParameter);
+        title = courseManager.getTitle(courseParameter) + " - " + title;
+      } else {
+        crawlersMakeListHeader(content, "course");
+        crawlersMakeCourseListContent(content);
+        title = "קורסים - " + title;
+      }
+    } else if (staffParameter !== null) {
+      if (crawlersMakeStaffContent(content, staffParameter)) {
+        title = staffParameter + " - " + title;
+      } else {
+        crawlersMakeListHeader(content, "staff");
+        crawlersMakeStaffListContent(content);
+        title = "סגל - " + title;
+      }
+    } else {
+      // if (roomParameter !== null)
+      if (crawlersMakeRoomContent(content, roomParameter)) {
+        title = roomParameter + " - " + title;
+      } else {
+        crawlersMakeListHeader(content, "room");
+        crawlersMakeRoomListContent(content);
+        title = "חדרים - " + title;
+      }
+    }
+
+    document.title = title;
+
+    $("#content-container").html(content);
+
+    $("#top-navbar-home").removeClass("d-none");
+    $("#top-navbar-share").addClass("d-none");
+    $("#top-navbar-export").addClass("d-none");
+    $("#top-navbar-semester").addClass("d-none");
+    $("#course-select").hide();
+
+    $("#top-navbar-supported-content").removeClass(
+      "top-navbar-content-uninitialized",
+    );
+
+    $("#footer-semester-name").text(semesterFriendlyName(currentSemester));
+    $("#footer-semester").removeClass("d-none");
+
+    // The filter form is indexed by Google even though it's hidden, so remove it.
+    $("#filter-form").remove();
+
+    $("#page-loader").hide();
+
+    return true;
+  }
+
+  function crawlersMakeListHeader(content, currentList) {
+    Object.keys(availableSemesters)
+      .sort()
+      .forEach(function (semester) {
+        var text = semesterFriendlyName(semester);
+        if (semester === currentSemester) {
+          content.append($("<span>").text(text));
         } else {
-            try {
-                courseNumbers.forEach(function (course) {
-                    var metadataCourseKey = currentSemester + '_metadata_' + course;
-                    var courseData = courseManager.getCourseData(course);
-                    localStorage.setItem(metadataCourseKey, JSON.stringify(courseData));
-                });
+          var url = "?semester=" + encodeURIComponent(semester) + "&course=all";
+          content.append($("<a>").text(text).prop("href", url));
+        }
+        content.append("<br>");
+      });
 
-                if (deletedCourses.length > 0) {
-                    localStorage.setItem(semesterCoursesKey, JSON.stringify(currentSavedSession[semesterCoursesKey]));
-                }
+    content.append("<br>");
 
-                deletedCourses.forEach(function (course) {
-                    var courseKey = currentSemester + '_' + course;
-                    localStorage.removeItem(courseKey);
+    var listToText = {
+      course: "קורסים",
+      staff: "סגל",
+      room: "חדרים",
+    };
 
-                    var metadataCourseKey = currentSemester + '_metadata_' + course;
-                    localStorage.removeItem(metadataCourseKey);
-                });
-            } catch (e) {
-                // localStorage is not available in IE/Edge when running from a local file.
-            }
+    ["course", "staff", "room"].forEach(function (list) {
+      var text = listToText[list];
+      if (list === currentList) {
+        content.append($("<span>").text(text));
+      } else {
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&" +
+          encodeURIComponent(list) +
+          "=all";
+        content.append($("<a>").text(text).prop("href", url));
+      }
+      content.append("<br>");
+    });
+
+    content.append("<br>");
+  }
+
+  function crawlersMakeCourseContent(content, course) {
+    var url =
+      "?semester=" + encodeURIComponent(currentSemester) + "&course=all";
+    content.append($("<a>").text("לרשימת הקורסים").prop("href", url));
+    content.append("<br><br>");
+
+    var description = courseManager.getDescription(course, {
+      html: true,
+      relatedCourseInfo: true,
+      links: true,
+    });
+    content.append($("<div>").html(description));
+
+    var lessonsAdded = {};
+    courseManager.getSchedule(course).forEach(function (lesson) {
+      if (
+        lessonsAdded[lesson["מס."]] &&
+        lessonsAdded[lesson["מס."]] !== lesson["קבוצה"]
+      ) {
+        return;
+      }
+
+      content.append("<br>");
+
+      var typeAndNumber = courseManager.getLessonTypeAndNumber(lesson);
+      content.append(
+        $('<div style="font-weight: bold;"></div>').text(typeAndNumber),
+      );
+
+      if (lesson["מרצה/מתרגל"]) {
+        var staffContents = $("<div>").text("מרצה/מתרגל" + ": ");
+        lesson["מרצה/מתרגל"].split("\n").forEach(function (name, i) {
+          if (i > 0) {
+            staffContents.append(", ");
+          }
+          var staffUrl =
+            "?semester=" +
+            encodeURIComponent(currentSemester) +
+            "&staff=" +
+            encodeURIComponent(name);
+          var staffLink = $("<a>").text(name).prop("href", staffUrl);
+          staffContents.append(staffLink);
+        });
+        content.append(staffContents);
+      }
+
+      if (lesson["יום"]) {
+        content.append($("<div>").text("יום" + ": " + lesson["יום"]));
+      }
+
+      if (lesson["שעה"]) {
+        content.append($("<div>").text("שעה" + ": " + lesson["שעה"]));
+      }
+
+      var roomUrl;
+      var roomLink;
+      if (lesson["בניין"] && lesson["חדר"]) {
+        content.append($("<div>").text("בניין" + ": " + lesson["בניין"]));
+        roomUrl =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&room=" +
+          encodeURIComponent(lesson["בניין"] + " " + lesson["חדר"]);
+        roomLink = $("<a>").text(lesson["חדר"]).prop("href", roomUrl);
+        content.append(
+          $("<div>")
+            .text("חדר" + ": ")
+            .append(roomLink),
+        );
+      } else if (lesson["בניין"]) {
+        roomUrl =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&room=" +
+          encodeURIComponent(lesson["בניין"]);
+        roomLink = $("<a>").text(lesson["בניין"]).prop("href", roomUrl);
+        content.append(
+          $("<div>")
+            .text("בניין" + ": ")
+            .append(roomLink),
+        );
+      } else if (lesson["חדר"]) {
+        content.append($("<div>").text("חדר" + ": " + lesson["חדר"]));
+      }
+
+      lessonsAdded[lesson["מס."]] = lesson["קבוצה"];
+    });
+  }
+
+  function crawlersMakeCourseListContent(content) {
+    courseManager
+      .getAllCourses()
+      .sort()
+      .forEach(function (cbCourse) {
+        var title = courseManager.getTitle(cbCourse);
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&course=" +
+          encodeURIComponent(cbCourse);
+        content.append($("<a>").text(title).prop("href", url));
+        content.append("<br>");
+      });
+  }
+
+  function crawlersMakeStaffContent(content, staff) {
+    var schedule = [];
+    courseManager.getAllCourses().forEach(function (course) {
+      var lessonsAdded = {};
+      courseManager.getSchedule(course).forEach(function (lesson) {
+        if (
+          lessonsAdded[lesson["מס."]] &&
+          lessonsAdded[lesson["מס."]] !== lesson["קבוצה"]
+        ) {
+          return;
         }
 
-        metadataDiff = {};
-        onMetadataDiffChange();
+        if (
+          lesson["מרצה/מתרגל"] &&
+          lesson["מרצה/מתרגל"].split("\n").indexOf(staff) !== -1
+        ) {
+          var time = null;
+          if (lesson["יום"]) {
+            if (lesson["שעה"]) {
+              time = "יום " + lesson["יום"] + " " + lesson["שעה"];
+            } else {
+              time = "יום " + lesson["יום"];
+            }
+          }
+
+          schedule.push({ course: course, time: time });
+        }
+
+        lessonsAdded[lesson["מס."]] = lesson["קבוצה"];
+      });
+    });
+
+    if (schedule.length === 0) {
+      return false;
     }
 
-    function onMetadataDiffChange() {
-        var badgeCount = 0;
+    var url = "?semester=" + encodeURIComponent(currentSemester) + "&staff=all";
+    content.append($("<a>").text("לרשימת הסגל").prop("href", url));
+    content.append("<br><br>");
 
-        if (metadataDiff) {
-            var diffCourses = Object.keys(metadataDiff);
-            if (diffCourses.length > 0) {
-                badgeCount = diffCourses.reduce(function (accumulator, course) {
-                    var diff = metadataDiff[course];
-                    return accumulator + (diff.exists ? diff.changes.length : 1);
-                }, 0);
-            }
+    content.append($("<b>").text(staff));
+    content.append("<br>");
+
+    schedule
+      .sort(function (a, b) {
+        if (!a.time && !b.time) {
+          return 0;
+        } else if (!a.time) {
+          return 1;
+        } else if (!b.time) {
+          return -1;
         } else {
-            // If !metadataDiff, that probably means that
-            // the user built the schedule before the feature was introduced.
-            badgeCount = 1;
+          var dayMapping = {
+            ראשון: "א",
+            שני: "ב",
+            שלישי: "ג",
+            רביעי: "ד",
+            חמישי: "ה",
+            שישי: "ו",
+          };
+
+          var aTimeForCompare = a.time.replace(
+            /^יום (\S+)/,
+            function (match, p1) {
+              return dayMapping[p1] || p1;
+            },
+          );
+          var bTimeForCompare = b.time.replace(
+            /^יום (\S+)/,
+            function (match, p1) {
+              return dayMapping[p1] || p1;
+            },
+          );
+
+          return aTimeForCompare.localeCompare(bTimeForCompare, undefined, {
+            numeric: true,
+          });
+        }
+      })
+      .forEach(function (item) {
+        if (item.time) {
+          content.append($("<span>").text(item.time + " - "));
         }
 
-        if (badgeCount > 0) {
-            $('#top-navbar-changes').removeClass('d-none').find('.unread-count-badge').text(badgeCount);
-            $('#top-navbar .navbar-toggler .unread-count-badge').text(badgeCount).removeClass('d-none');
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&course=" +
+          encodeURIComponent(item.course);
+        var courseTitle = courseManager.getTitle(item.course);
+        content.append($("<a>").text(courseTitle).prop("href", url));
+        content.append("<br>");
+      });
+
+    return true;
+  }
+
+  function crawlersMakeStaffListContent(content) {
+    var staff = {};
+    courseManager.getAllCourses().forEach(function (course) {
+      courseManager.getSchedule(course).forEach(function (lesson) {
+        if (lesson["מרצה/מתרגל"]) {
+          lesson["מרצה/מתרגל"].split("\n").forEach(function (name) {
+            staff[name] = true;
+          });
+        }
+      });
+    });
+
+    Object.keys(staff)
+      .sort()
+      .forEach(function (name) {
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&staff=" +
+          encodeURIComponent(name);
+        content.append($("<a>").text(name).prop("href", url));
+        content.append("<br>");
+      });
+  }
+
+  function crawlersMakeRoomContent(content, room) {
+    var schedule = [];
+    courseManager.getAllCourses().forEach(function (course) {
+      var lessonsAdded = {};
+      courseManager.getSchedule(course).forEach(function (lesson) {
+        if (
+          lessonsAdded[lesson["מס."]] &&
+          lessonsAdded[lesson["מס."]] !== lesson["קבוצה"]
+        ) {
+          return;
+        }
+
+        var roomCompare = null;
+        if (lesson["בניין"]) {
+          if (lesson["חדר"]) {
+            roomCompare = lesson["בניין"] + " " + lesson["חדר"];
+          } else {
+            roomCompare = lesson["בניין"];
+          }
+        }
+
+        if (roomCompare && room === roomCompare) {
+          var time = null;
+          if (lesson["יום"]) {
+            if (lesson["שעה"]) {
+              time = "יום " + lesson["יום"] + " " + lesson["שעה"];
+            } else {
+              time = "יום " + lesson["יום"];
+            }
+          }
+
+          schedule.push({ course: course, time: time });
+        }
+
+        lessonsAdded[lesson["מס."]] = lesson["קבוצה"];
+      });
+    });
+
+    if (schedule.length === 0) {
+      return false;
+    }
+
+    var url = "?semester=" + encodeURIComponent(currentSemester) + "&room=all";
+    content.append($("<a>").text("לרשימת החדרים").prop("href", url));
+    content.append("<br><br>");
+
+    content.append($("<b>").text(room));
+    content.append("<br>");
+
+    schedule
+      .sort(function (a, b) {
+        if (!a.time && !b.time) {
+          return 0;
+        } else if (!a.time) {
+          return 1;
+        } else if (!b.time) {
+          return -1;
         } else {
-            $('#top-navbar-changes').addClass('d-none');
-            $('#top-navbar .navbar-toggler .unread-count-badge').addClass('d-none');
+          var dayMapping = {
+            ראשון: "א",
+            שני: "ב",
+            שלישי: "ג",
+            רביעי: "ד",
+            חמישי: "ה",
+            שישי: "ו",
+          };
+
+          var aTimeForCompare = a.time.replace(
+            /^יום (\S+)/,
+            function (match, p1) {
+              return dayMapping[p1] || p1;
+            },
+          );
+          var bTimeForCompare = b.time.replace(
+            /^יום (\S+)/,
+            function (match, p1) {
+              return dayMapping[p1] || p1;
+            },
+          );
+
+          return aTimeForCompare.localeCompare(bTimeForCompare, undefined, {
+            numeric: true,
+          });
         }
-    }
-
-    // https://stackoverflow.com/a/30810322
-    function copyToClipboard(text, onSuccess, onFailure) {
-        if (!navigator.clipboard) {
-            fallbackCopyTextToClipboard(text);
-            return;
-        }
-        // eslint-disable-next-line compat/compat
-        navigator.clipboard.writeText(text).then(function () {
-            onSuccess();
-        }, function (err) {
-            onFailure();
-        });
-
-        function fallbackCopyTextToClipboard(text) {
-            var textArea = document.createElement('textarea');
-            textArea.value = text;
-            document.body.appendChild(textArea);
-            textArea.focus();
-            textArea.select();
-
-            var successful = false;
-            try {
-                successful = document.execCommand('copy');
-            } catch (err) {
-                // We tried...
-            }
-
-            document.body.removeChild(textArea);
-
-            if (successful) {
-                onSuccess();
-            } else {
-                onFailure();
-            }
-        }
-    }
-
-    function crawlersInfo() {
-        var courseParameter = getParameterByName('course');
-        var staffParameter = getParameterByName('staff');
-        var roomParameter = getParameterByName('room');
-
-        if (courseParameter === null && staffParameter === null && roomParameter === null) {
-            return false;
+      })
+      .forEach(function (item) {
+        if (item.time) {
+          content.append($("<span>").text(item.time + " - "));
         }
 
-        var content = $('<div class="col-md-12"></div>');
-        var title = semesterFriendlyName(currentSemester) + ' - CheeseFork';
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&course=" +
+          encodeURIComponent(item.course);
+        var courseTitle = courseManager.getTitle(item.course);
+        content.append($("<a>").text(courseTitle).prop("href", url));
+        content.append("<br>");
+      });
 
-        if (courseParameter !== null) {
-            if (courseManager.doesExist(courseParameter)) {
-                crawlersMakeCourseContent(content, courseParameter);
-                title = courseManager.getTitle(courseParameter) + ' - ' + title;
-            } else {
-                crawlersMakeListHeader(content, 'course');
-                crawlersMakeCourseListContent(content);
-                title = 'קורסים - ' + title;
-            }
-        } else if (staffParameter !== null) {
-            if (crawlersMakeStaffContent(content, staffParameter)) {
-                title = staffParameter + ' - ' + title;
-            } else {
-                crawlersMakeListHeader(content, 'staff');
-                crawlersMakeStaffListContent(content);
-                title = 'סגל - ' + title;
-            }
-        } else { // if (roomParameter !== null)
-            if (crawlersMakeRoomContent(content, roomParameter)) {
-                title = roomParameter + ' - ' + title;
-            } else {
-                crawlersMakeListHeader(content, 'room');
-                crawlersMakeRoomListContent(content);
-                title = 'חדרים - ' + title;
-            }
+    return true;
+  }
+
+  function crawlersMakeRoomListContent(content) {
+    var rooms = {};
+    courseManager.getAllCourses().forEach(function (course) {
+      courseManager.getSchedule(course).forEach(function (lesson) {
+        if (lesson["בניין"]) {
+          if (lesson["חדר"]) {
+            rooms[lesson["בניין"] + " " + lesson["חדר"]] = true;
+          } else {
+            rooms[lesson["בניין"]] = true;
+          }
         }
+      });
+    });
 
-        document.title = title;
+    Object.keys(rooms)
+      .sort()
+      .forEach(function (room) {
+        var url =
+          "?semester=" +
+          encodeURIComponent(currentSemester) +
+          "&room=" +
+          encodeURIComponent(room);
+        content.append($("<a>").text(room).prop("href", url));
+        content.append("<br>");
+      });
+  }
 
-        $('#content-container').html(content);
+  // https://stackoverflow.com/a/901144
+  function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+      results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return "";
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+  }
 
-        $('#top-navbar-home').removeClass('d-none');
-        $('#top-navbar-share').addClass('d-none');
-        $('#top-navbar-export').addClass('d-none');
-        $('#top-navbar-semester').addClass('d-none');
-        $('#course-select').hide();
-
-        $('#top-navbar-supported-content').removeClass('top-navbar-content-uninitialized');
-
-        $('#footer-semester-name').text(semesterFriendlyName(currentSemester));
-        $('#footer-semester').removeClass('d-none');
-
-        // The filter form is indexed by Google even though it's hidden, so remove it.
-        $('#filter-form').remove();
-
-        $('#page-loader').hide();
-
-        return true;
-    }
-
-    function crawlersMakeListHeader(content, currentList) {
-        Object.keys(availableSemesters).sort().forEach(function (semester) {
-            var text = semesterFriendlyName(semester);
-            if (semester === currentSemester) {
-                content.append($('<span>').text(text));
-            } else {
-                var url = '?semester=' + encodeURIComponent(semester) + '&course=all';
-                content.append($('<a>').text(text).prop('href', url));
-            }
-            content.append('<br>');
-        });
-
-        content.append('<br>');
-
-        var listToText = {
-            'course': 'קורסים',
-            'staff': 'סגל',
-            'room': 'חדרים'
-        };
-
-        ['course', 'staff', 'room'].forEach(function (list) {
-            var text = listToText[list];
-            if (list === currentList) {
-                content.append($('<span>').text(text));
-            } else {
-                var url = '?semester=' + encodeURIComponent(currentSemester) + '&' + encodeURIComponent(list) + '=all';
-                content.append($('<a>').text(text).prop('href', url));
-            }
-            content.append('<br>');
-        });
-
-        content.append('<br>');
-    }
-
-    function crawlersMakeCourseContent(content, course) {
-        var url = '?semester=' + encodeURIComponent(currentSemester) + '&course=all';
-        content.append($('<a>').text('לרשימת הקורסים').prop('href', url));
-        content.append('<br><br>');
-
-        var description = courseManager.getDescription(course, {html: true, relatedCourseInfo: true, links: true});
-        content.append($('<div>').html(description));
-
-        var lessonsAdded = {};
-        courseManager.getSchedule(course).forEach(function (lesson) {
-            if (lessonsAdded[lesson['מס.']] && lessonsAdded[lesson['מס.']] !== lesson['קבוצה']) {
-                return;
-            }
-
-            content.append('<br>');
-
-            var typeAndNumber = courseManager.getLessonTypeAndNumber(lesson);
-            content.append($('<div style="font-weight: bold;"></div>').text(typeAndNumber));
-
-            if (lesson['מרצה/מתרגל']) {
-                var staffContents = $('<div>').text('מרצה/מתרגל' + ': ');
-                lesson['מרצה/מתרגל'].split('\n').forEach(function (name, i) {
-                    if (i > 0) {
-                        staffContents.append(', ');
-                    }
-                    var staffUrl = '?semester=' + encodeURIComponent(currentSemester) + '&staff=' + encodeURIComponent(name);
-                    var staffLink = $('<a>').text(name).prop('href', staffUrl);
-                    staffContents.append(staffLink);
-                });
-                content.append(staffContents);
-            }
-
-            if (lesson['יום']) {
-                content.append($('<div>').text('יום' + ': ' + lesson['יום']));
-            }
-
-            if (lesson['שעה']) {
-                content.append($('<div>').text('שעה' + ': ' + lesson['שעה']));
-            }
-
-            var roomUrl;
-            var roomLink;
-            if (lesson['בניין'] && lesson['חדר']) {
-                content.append($('<div>').text('בניין' + ': ' + lesson['בניין']));
-                roomUrl = '?semester=' + encodeURIComponent(currentSemester) + '&room=' + encodeURIComponent(lesson['בניין'] + ' ' + lesson['חדר']);
-                roomLink = $('<a>').text(lesson['חדר']).prop('href', roomUrl);
-                content.append($('<div>').text('חדר' + ': ').append(roomLink));
-            } else if (lesson['בניין']) {
-                roomUrl = '?semester=' + encodeURIComponent(currentSemester) + '&room=' + encodeURIComponent(lesson['בניין']);
-                roomLink = $('<a>').text(lesson['בניין']).prop('href', roomUrl);
-                content.append($('<div>').text('בניין' + ': ').append(roomLink));
-            } else if (lesson['חדר']) {
-                content.append($('<div>').text('חדר' + ': ' + lesson['חדר']));
-            }
-
-            lessonsAdded[lesson['מס.']] = lesson['קבוצה'];
-        });
-    }
-
-    function crawlersMakeCourseListContent(content) {
-        courseManager.getAllCourses().sort().forEach(function (cbCourse) {
-            var title = courseManager.getTitle(cbCourse);
-            var url = '?semester=' + encodeURIComponent(currentSemester) + '&course=' + encodeURIComponent(cbCourse);
-            content.append($('<a>').text(title).prop('href', url));
-            content.append('<br>');
-        });
-    }
-
-    function crawlersMakeStaffContent(content, staff) {
-        var schedule = [];
-        courseManager.getAllCourses().forEach(function (course) {
-            var lessonsAdded = {};
-            courseManager.getSchedule(course).forEach(function (lesson) {
-                if (lessonsAdded[lesson['מס.']] && lessonsAdded[lesson['מס.']] !== lesson['קבוצה']) {
-                    return;
-                }
-
-                if (lesson['מרצה/מתרגל'] && lesson['מרצה/מתרגל'].split('\n').indexOf(staff) !== -1) {
-                    var time = null;
-                    if (lesson['יום']) {
-                        if (lesson['שעה']) {
-                            time = 'יום ' + lesson['יום'] + ' ' + lesson['שעה'];
-                        } else {
-                            time = 'יום ' + lesson['יום'];
-                        }
-                    }
-
-                    schedule.push({course: course, time: time});
-                }
-
-                lessonsAdded[lesson['מס.']] = lesson['קבוצה'];
-            });
-        });
-
-        if (schedule.length === 0) {
-            return false;
-        }
-
-        var url = '?semester=' + encodeURIComponent(currentSemester) + '&staff=all';
-        content.append($('<a>').text('לרשימת הסגל').prop('href', url));
-        content.append('<br><br>');
-
-        content.append($('<b>').text(staff));
-        content.append('<br>');
-
-        schedule.sort(function (a, b) {
-            if (!a.time && !b.time) {
-                return 0;
-            } else if (!a.time) {
-                return 1;
-            } else if (!b.time) {
-                return -1;
-            } else {
-                var dayMapping = {
-                    'ראשון': 'א',
-                    'שני': 'ב',
-                    'שלישי': 'ג',
-                    'רביעי': 'ד',
-                    'חמישי': 'ה',
-                    'שישי': 'ו',
-                };
-
-                var aTimeForCompare = a.time.replace(/^יום (\S+)/, function (match, p1) {
-                    return dayMapping[p1] || p1;
-                });
-                var bTimeForCompare = b.time.replace(/^יום (\S+)/, function (match, p1) {
-                    return dayMapping[p1] || p1;
-                });
-
-                return aTimeForCompare.localeCompare(bTimeForCompare, undefined, { numeric: true });
-            }
-        }).forEach(function (item) {
-            if (item.time) {
-                content.append($('<span>').text(item.time + ' - '));
-            }
-
-            var url = '?semester=' + encodeURIComponent(currentSemester) + '&course=' + encodeURIComponent(item.course);
-            var courseTitle = courseManager.getTitle(item.course);
-            content.append($('<a>').text(courseTitle).prop('href', url));
-            content.append('<br>');
-        });
-
-        return true;
-    }
-
-    function crawlersMakeStaffListContent(content) {
-        var staff = {};
-        courseManager.getAllCourses().forEach(function (course) {
-            courseManager.getSchedule(course).forEach(function (lesson) {
-                if (lesson['מרצה/מתרגל']) {
-                    lesson['מרצה/מתרגל'].split('\n').forEach(function (name) {
-                        staff[name] = true;
-                    });
-                }
-            });
-        });
-
-        Object.keys(staff).sort().forEach(function (name) {
-            var url = '?semester=' + encodeURIComponent(currentSemester) + '&staff=' + encodeURIComponent(name);
-            content.append($('<a>').text(name).prop('href', url));
-            content.append('<br>');
-        });
-    }
-
-    function crawlersMakeRoomContent(content, room) {
-        var schedule = [];
-        courseManager.getAllCourses().forEach(function (course) {
-            var lessonsAdded = {};
-            courseManager.getSchedule(course).forEach(function (lesson) {
-                if (lessonsAdded[lesson['מס.']] && lessonsAdded[lesson['מס.']] !== lesson['קבוצה']) {
-                    return;
-                }
-
-                var roomCompare = null;
-                if (lesson['בניין']) {
-                    if (lesson['חדר']) {
-                        roomCompare = lesson['בניין'] + ' ' + lesson['חדר'];
-                    } else {
-                        roomCompare = lesson['בניין'];
-                    }
-                }
-
-                if (roomCompare && room === roomCompare) {
-                    var time = null;
-                    if (lesson['יום']) {
-                        if (lesson['שעה']) {
-                            time = 'יום ' + lesson['יום'] + ' ' + lesson['שעה'];
-                        } else {
-                            time = 'יום ' + lesson['יום'];
-                        }
-                    }
-
-                    schedule.push({course: course, time: time});
-                }
-
-                lessonsAdded[lesson['מס.']] = lesson['קבוצה'];
-            });
-        });
-
-        if (schedule.length === 0) {
-            return false;
-        }
-
-        var url = '?semester=' + encodeURIComponent(currentSemester) + '&room=all';
-        content.append($('<a>').text('לרשימת החדרים').prop('href', url));
-        content.append('<br><br>');
-
-        content.append($('<b>').text(room));
-        content.append('<br>');
-
-        schedule.sort(function (a, b) {
-            if (!a.time && !b.time) {
-                return 0;
-            } else if (!a.time) {
-                return 1;
-            } else if (!b.time) {
-                return -1;
-            } else {
-                var dayMapping = {
-                    'ראשון': 'א',
-                    'שני': 'ב',
-                    'שלישי': 'ג',
-                    'רביעי': 'ד',
-                    'חמישי': 'ה',
-                    'שישי': 'ו',
-                };
-
-                var aTimeForCompare = a.time.replace(/^יום (\S+)/, function (match, p1) {
-                    return dayMapping[p1] || p1;
-                });
-                var bTimeForCompare = b.time.replace(/^יום (\S+)/, function (match, p1) {
-                    return dayMapping[p1] || p1;
-                });
-
-                return aTimeForCompare.localeCompare(bTimeForCompare, undefined, { numeric: true });
-            }
-        }).forEach(function (item) {
-            if (item.time) {
-                content.append($('<span>').text(item.time + ' - '));
-            }
-
-            var url = '?semester=' + encodeURIComponent(currentSemester) + '&course=' + encodeURIComponent(item.course);
-            var courseTitle = courseManager.getTitle(item.course);
-            content.append($('<a>').text(courseTitle).prop('href', url));
-            content.append('<br>');
-        });
-
-        return true;
-    }
-
-    function crawlersMakeRoomListContent(content) {
-        var rooms = {};
-        courseManager.getAllCourses().forEach(function (course) {
-            courseManager.getSchedule(course).forEach(function (lesson) {
-                if (lesson['בניין']) {
-                    if (lesson['חדר']) {
-                        rooms[lesson['בניין'] + ' ' + lesson['חדר']] = true;
-                    } else {
-                        rooms[lesson['בניין']] = true;
-                    }
-                }
-            });
-        });
-
-        Object.keys(rooms).sort().forEach(function (room) {
-            var url = '?semester=' + encodeURIComponent(currentSemester) + '&room=' + encodeURIComponent(room);
-            content.append($('<a>').text(room).prop('href', url));
-            content.append('<br>');
-        });
-    }
-
-    // https://stackoverflow.com/a/901144
-    function getParameterByName(name, url) {
-        if (!url) url = window.location.href;
-        name = name.replace(/[[\]]/g, "\\$&");
-        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-            results = regex.exec(url);
-        if (!results) return null;
-        if (!results[2]) return '';
-        return decodeURIComponent(results[2].replace(/\+/g, " "));
-    }
-
-    // https://stackoverflow.com/a/19015262
-    function getScrollBarWidth() {
-        var $outer = $('<div>').css({visibility: 'hidden', width: 100, overflow: 'scroll'}).appendTo('body'),
-            widthWithScroll = $('<div>').css({width: '100%'}).appendTo($outer).outerWidth();
-        $outer.remove();
-        return 100 - widthWithScroll;
-    }
+  // https://stackoverflow.com/a/19015262
+  function getScrollBarWidth() {
+    var $outer = $("<div>")
+        .css({ visibility: "hidden", width: 100, overflow: "scroll" })
+        .appendTo("body"),
+      widthWithScroll = $("<div>")
+        .css({ width: "100%" })
+        .appendTo($outer)
+        .outerWidth();
+    $outer.remove();
+    return 100 - widthWithScroll;
+  }
 })();
 
 // eslint-disable-next-line no-unused-vars
 function showBootstrapDialogWithModelessButton(dialogName, options) {
-    var newOptions = $.extend({}, options, {
-        onshow: function (dialog) {
-            var restoreButton = $('<div class="bootstrap-dialog-close-button" style="margin-right: auto;">' +
-                '<button class="close d-none d-sm-inline-block">' +
-                '<i class="far fa-window-restore" style="font-size: 18px;"></i>' +
-                '</button>' +
-                '</div>');
+  var newOptions = $.extend({}, options, {
+    onshow: function (dialog) {
+      var restoreButton = $(
+        '<div class="bootstrap-dialog-close-button" style="margin-right: auto;">' +
+          '<button class="close d-none d-sm-inline-block">' +
+          '<i class="far fa-window-restore" style="font-size: 18px;"></i>' +
+          "</button>" +
+          "</div>",
+      );
 
-            dialog.getModalHeader().find('.bootstrap-dialog-close-button').before(restoreButton);
+      dialog
+        .getModalHeader()
+        .find(".bootstrap-dialog-close-button")
+        .before(restoreButton);
 
-            restoreButton.click(function () {
-                gtag('event', 'bootstrap-dialog-restore-' + dialogName);
+      restoreButton.click(function () {
+        gtag("event", "bootstrap-dialog-restore-" + dialogName);
 
-                restoreButton.hide();
+        restoreButton.hide();
 
-                $('body').removeClass('modal-open').css({
-                    'padding-right': ''
-                }).find('> .modal-backdrop').hide();
+        $("body")
+          .removeClass("modal-open")
+          .css({
+            "padding-right": "",
+          })
+          .find("> .modal-backdrop")
+          .hide();
 
-                var numOfModelessDialogs = $('body > .bootstrap-dialog.cheesefork-modeless-dialog').length;
+        var numOfModelessDialogs = $(
+          "body > .bootstrap-dialog.cheesefork-modeless-dialog",
+        ).length;
 
-                var thatDialogModal = dialog.getModal();
-                thatDialogModal.removeClass('modal')
-                    .addClass('cheesefork-modeless-dialog')
-                    .css('z-index', 1000 + numOfModelessDialogs)
-                    .click(function () {
-                        var modelessDialogs = $('body > .bootstrap-dialog.cheesefork-modeless-dialog');
-                        var prevZIndex = thatDialogModal.css('z-index');
-                        if (prevZIndex < 1000 + modelessDialogs.length - 1) {
-                            modelessDialogs.each(function () {
-                                var iter = $(this);
-                                if (iter.css('z-index') > prevZIndex) {
-                                    iter.css('z-index', iter.css('z-index') - 1);
-                                }
-                            });
-
-                            thatDialogModal.css('z-index', 1000 + modelessDialogs.length - 1);
-                        }
-                    });
-
-                dialog.options.draggable = true;
-                dialog.makeModalDraggable();
-            });
-
-            if (options.onshow) {
-                options.onshow(dialog);
-            }
-        },
-        onhidden: function (dialog) {
-            var thatDialogModal = dialog.getModal();
-            var modelessDialogs = $('body > .bootstrap-dialog.cheesefork-modeless-dialog');
-            var prevZIndex = thatDialogModal.css('z-index');
+        var thatDialogModal = dialog.getModal();
+        thatDialogModal
+          .removeClass("modal")
+          .addClass("cheesefork-modeless-dialog")
+          .css("z-index", 1000 + numOfModelessDialogs)
+          .click(function () {
+            var modelessDialogs = $(
+              "body > .bootstrap-dialog.cheesefork-modeless-dialog",
+            );
+            var prevZIndex = thatDialogModal.css("z-index");
             if (prevZIndex < 1000 + modelessDialogs.length - 1) {
-                modelessDialogs.each(function () {
-                    var iter = $(this);
-                    if (iter.css('z-index') > prevZIndex) {
-                        iter.css('z-index', iter.css('z-index') - 1);
-                    }
-                });
-            }
+              modelessDialogs.each(function () {
+                var iter = $(this);
+                if (iter.css("z-index") > prevZIndex) {
+                  iter.css("z-index", iter.css("z-index") - 1);
+                }
+              });
 
-            if (options.onhidden) {
-                options.onhidden(dialog);
+              thatDialogModal.css("z-index", 1000 + modelessDialogs.length - 1);
             }
-        }
-    });
+          });
 
-    return BootstrapDialog.show(newOptions);
+        dialog.options.draggable = true;
+        dialog.makeModalDraggable();
+      });
+
+      if (options.onshow) {
+        options.onshow(dialog);
+      }
+    },
+    onhidden: function (dialog) {
+      var thatDialogModal = dialog.getModal();
+      var modelessDialogs = $(
+        "body > .bootstrap-dialog.cheesefork-modeless-dialog",
+      );
+      var prevZIndex = thatDialogModal.css("z-index");
+      if (prevZIndex < 1000 + modelessDialogs.length - 1) {
+        modelessDialogs.each(function () {
+          var iter = $(this);
+          if (iter.css("z-index") > prevZIndex) {
+            iter.css("z-index", iter.css("z-index") - 1);
+          }
+        });
+      }
+
+      if (options.onhidden) {
+        options.onhidden(dialog);
+      }
+    },
+  });
+
+  return BootstrapDialog.show(newOptions);
 }

--- a/cheesefork.js
+++ b/cheesefork.js
@@ -1053,13 +1053,12 @@
 
   function firebaseInit() {
     var config = {
-      apiKey: "AIzaSyCyxZsBibBcN5qq-rqVC9CqvW1bFo5fjnc",
-      authDomain: "cheese-fork-local.firebaseapp.com",
-      projectId: "cheese-fork-local",
-      storageBucket: "cheese-fork-local.firebasestorage.app",
-      messagingSenderId: "1089831905501",
-      appId: "1:1089831905501:web:98aa0b336071e691e4d334",
-      measurementId: "G-GSXTEPRH3K",
+      apiKey: 'AIzaSyAfKPyTM83mkLgdQTdx9YS9UXywiswwIYI',
+      authDomain: 'cheesefork-de9af.firebaseapp.com',
+      databaseURL: 'https://cheesefork-de9af.firebaseio.com',
+      projectId: 'cheesefork-de9af',
+      storageBucket: 'cheesefork-de9af.appspot.com',
+      messagingSenderId: '916559682433'
     };
     firebase.initializeApp(config);
 

--- a/course-widget-comments.html
+++ b/course-widget-comments.html
@@ -1,115 +1,130 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="he" dir="rtl">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
     <title>CheeseFork - חוות דעת</title>
-    <link rel="shortcut icon" href="favicon.ico">
-    <link rel="stylesheet" href="modules/bootstrap-rtl/css/bootstrap.min.css">
-    <link rel="stylesheet" href="modules/bootstrap4-dialog/css/bootstrap-dialog.min.css">
-    <link rel="stylesheet" href="modules/fontawesome/css/all.min.css">
-    <link rel="stylesheet" href="components/course-feedback/course-feedback.css">
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="stylesheet" href="modules/bootstrap-rtl/css/bootstrap.min.css" />
+    <link
+      rel="stylesheet"
+      href="modules/bootstrap4-dialog/css/bootstrap-dialog.min.css"
+    />
+    <link rel="stylesheet" href="modules/fontawesome/css/all.min.css" />
+    <link
+      rel="stylesheet"
+      href="components/course-feedback/course-feedback.css"
+    />
     <style>
-        .footer-promo {
-            position: fixed;
-            bottom: -10px;
-            left: 10px;
-            border-style: solid;
-            border-width: thin;
-            border-radius: 8px;
-            padding: 10px;
-        }
+      .footer-promo {
+        position: fixed;
+        bottom: -10px;
+        left: 10px;
+        border-style: solid;
+        border-width: thin;
+        border-radius: 8px;
+        padding: 10px;
+      }
     </style>
-</head>
-<body class="bg-light my-3">
-<div class="container-fluid">
-    <div id="content-container">
+  </head>
+  <body class="bg-light my-3">
+    <div class="container-fluid">
+      <div id="content-container">
         <div class="course-feedback"></div>
         <div class="bg-light footer-promo">
-            <a target="_blank" href=".">
-                <img src="logo.png" alt="logo" height="30">
-                <span class="font-weight-bold">CheeseFork</span>
-            </a>
+          <a target="_blank" href=".">
+            <img src="logo.png" alt="logo" height="30" />
+            <span class="font-weight-bold">CheeseFork</span>
+          </a>
         </div>
+      </div>
     </div>
-</div>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-115440973-1"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-115440973-1"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-    gtag('config', 'UA-115440973-1');
-</script>
-<script src="modules/fullcalendar/lib/jquery.min.js"></script>
-<script src="modules/popper/popper.js"></script>
-<script src="modules/bootstrap-rtl/js/bootstrap.min.js"></script>
-<script src="modules/bootstrap4-dialog/js/bootstrap-dialog.min.js"></script>
-<script src="components/course-feedback/course-feedback.js"></script>
-<script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-app-compat.js"></script>
-<script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-auth-compat.js"></script>
-<script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-firestore-compat.js"></script>
-<script>
-    // https://stackoverflow.com/a/901144
-    function getParameterByName(name, url) {
+      gtag("config", "UA-115440973-1");
+    </script>
+    <script src="modules/fullcalendar/lib/jquery.min.js"></script>
+    <script src="modules/popper/popper.js"></script>
+    <script src="modules/bootstrap-rtl/js/bootstrap.min.js"></script>
+    <script src="modules/bootstrap4-dialog/js/bootstrap-dialog.min.js"></script>
+    <script src="components/course-feedback/course-feedback.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/12.4.0/firebase-firestore-compat.js"></script>
+    <script>
+      // https://stackoverflow.com/a/901144
+      function getParameterByName(name, url) {
         if (!url) url = window.location.href;
         name = name.replace(/[\[\]]/g, "\\$&");
         var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-            results = regex.exec(url);
+          results = regex.exec(url);
         if (!results) return null;
-        if (!results[2]) return '';
+        if (!results[2]) return "";
         return decodeURIComponent(results[2].replace(/\+/g, " "));
-    }
+      }
 
-    function toNewCourseNumber(course) {
+      function toNewCourseNumber(course) {
         var match = /^9730(\d\d)$/.exec(course);
         if (match) {
-            return '970300' + match[1];
+          return "970300" + match[1];
         }
 
         match = /^(\d\d\d)(\d\d\d)$/.exec(course);
         if (match) {
-            return '0' + match[1] + '0' + match[2];
+          return "0" + match[1] + "0" + match[2];
         }
 
         return course;
-    }
+      }
 
-    function stringToCourseNumber(str) {
+      function stringToCourseNumber(str) {
         if (!str || !/^[0-9]{1,8}$/.test(str)) {
-            return null;
+          return null;
         }
 
         if (str.length <= 6) {
-            return toNewCourseNumber(('00000' + str).slice(-6));
+          return toNewCourseNumber(("00000" + str).slice(-6));
         } else {
-            return ('0000000' + str).slice(-8);
+          return ("0000000" + str).slice(-8);
         }
-    }
+      }
 
-    function firebaseInit() {
+      function firebaseInit() {
         var config = {
-            apiKey: 'AIzaSyAfKPyTM83mkLgdQTdx9YS9UXywiswwIYI',
-            authDomain: 'cheesefork-de9af.firebaseapp.com',
-            databaseURL: 'https://cheesefork-de9af.firebaseio.com',
-            projectId: 'cheesefork-de9af',
-            storageBucket: 'cheesefork-de9af.appspot.com',
-            messagingSenderId: '916559682433'
+          apiKey: "AIzaSyCyxZsBibBcN5qq-rqVC9CqvW1bFo5fjnc",
+          authDomain: "cheese-fork-local.firebaseapp.com",
+          projectId: "cheese-fork-local",
+          storageBucket: "cheese-fork-local.firebasestorage.app",
+          messagingSenderId: "1089831905501",
+          appId: "1:1089831905501:web:98aa0b336071e691e4d334",
+          measurementId: "G-GSXTEPRH3K",
         };
         firebase.initializeApp(config);
-    }
+      }
 
-    var course = stringToCourseNumber(getParameterByName('course'));
-    if (course) {
+      var course = stringToCourseNumber(getParameterByName("course"));
+      if (course) {
         firebaseInit();
-        var courseFeedback = new CourseFeedback($('.course-feedback'), {
-            columnGrid: 'md',
-            openNewFeedbackDialog: getParameterByName('publish') !== null,
-            loginUrl: '.'
+        var courseFeedback = new CourseFeedback($(".course-feedback"), {
+          columnGrid: "md",
+          openNewFeedbackDialog: getParameterByName("publish") !== null,
+          loginUrl: ".",
         });
         courseFeedback.loadFeedback(course);
-    }
-</script>
-</body>
+      }
+    </script>
+  </body>
 </html>

--- a/course-widget-comments.html
+++ b/course-widget-comments.html
@@ -104,13 +104,12 @@
 
       function firebaseInit() {
         var config = {
-          apiKey: "AIzaSyCyxZsBibBcN5qq-rqVC9CqvW1bFo5fjnc",
-          authDomain: "cheese-fork-local.firebaseapp.com",
-          projectId: "cheese-fork-local",
-          storageBucket: "cheese-fork-local.firebasestorage.app",
-          messagingSenderId: "1089831905501",
-          appId: "1:1089831905501:web:98aa0b336071e691e4d334",
-          measurementId: "G-GSXTEPRH3K",
+          apiKey: "AIzaSyAfKPyTM83mkLgdQTdx9YS9UXywiswwIYI",
+          authDomain: "cheesefork-de9af.firebaseapp.com",
+          databaseURL: "https://cheesefork-de9af.firebaseio.com",
+          projectId: "cheesefork-de9af",
+          storageBucket: "cheesefork-de9af.appspot.com",
+          messagingSenderId: "916559682433",
         };
         firebase.initializeApp(config);
       }

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                 <li id="top-navbar-semester" class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="top-navbar-dropdown-semester" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class="fas fa-calendar-alt"></i>
-                        סמסטר
+                        סמסטר <span id="top-navbar-dropdown-semester-name"></span>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="top-navbar-dropdown-semester"></div>
                 </li>


### PR DESCRIPTION
## Summary

This PR updates the navbar semester selector so it shows the currently selected semester directly in the dropdown label, making the active semester easier to see without opening the menu.

It also adds lightweight project documentation:
- A new README overview explaining what CheeseFork does, the main features, architecture, tech stack, repository structure, and development notes.
- A complete local setup guide covering Firebase configuration, Authentication, Firestore, Storage rules, local serving, linting, and manual testing steps.

## Changes

- Display the current semester name next to the semester dropdown in the top navbar.
- Populate the navbar semester label dynamically using the existing `semesterFriendlyName(currentSemester)` helper.
- Add a clearer README for contributors and maintainers.
- Add a detailed `LOCAL_SETUP.md` guide for running the project locally with a personal Firebase project.

Updated Navbar:
<img width="1077" height="67" alt="image" src="https://github.com/user-attachments/assets/3723f100-3d50-46f4-a869-8f476b5225db" />

## Testing

- Verified the navbar still uses the existing semester dropdown behavior.
- Confirmed the current semester label is rendered through the existing navbar initialization flow.
- Documentation changes are Markdown-only and do not affect runtime behavior.